### PR TITLE
Add ObjData bounds checking in LoadCharacterInventory & LoadCharacterBank

### DIFF
--- a/Codigo/CharacterPersistence.bas
+++ b/Codigo/CharacterPersistence.bas
@@ -69,7 +69,7 @@ Public Function LoadCharacterBank(ByVal UserIndex As Integer) As Boolean
 368         If Not RS Is Nothing Then
 372             While Not RS.EOF
 374                 With .BancoInvent.Object(RS!Number)
-376                     .ObjIndex = RS!item_id
+376                     .ObjIndex = IIf(RS!item_id < UBound(ObjData), RS!item_id, 0)
 378                     If .ObjIndex <> 0 Then
 380                         If LenB(ObjData(.ObjIndex).name) Then
                                 counter = counter + 1
@@ -101,7 +101,7 @@ Public Function LoadCharacterInventory(ByVal UserIndex As Integer) As Boolean
 106         If Not RS Is Nothing Then
 108             While Not RS.EOF
 110                 With .invent.Object(RS!Number)
-112                     .ObjIndex = RS!item_id
+112                     .ObjIndex = IIf(RS!item_id < UBound(ObjData), RS!item_id, 0)
 114                     If .ObjIndex <> 0 Then
 116                         If LenB(ObjData(.ObjIndex).name) Then
 118                             counter = counter + 1

--- a/Codigo/frmMain.frm
+++ b/Codigo/frmMain.frm
@@ -1527,25 +1527,25 @@ HayError:
     Call TraceError(Err.Number, Err.Description & vbNewLine & "UserIndex:" & iUserIndex, "frmMain.GameTimer", Erl)
 End Sub
 
-Private Sub HoraFantasia_Timer()
-        
-    On Error GoTo HoraFantasia_Timer_Err
-    If Lloviendo Then
-        Label6.Caption = "Lloviendo"
-    Else
-        Label6.Caption = "No llueve"
-    End If
-
-    If ServidorNublado Then
-        Label7.Caption = "Nublado"
-    Else
-        Label7.Caption = "Sin nubes"
-    End If
-    frmMain.Label4.Caption = GetTimeFormated
-    Exit Sub
-HoraFantasia_Timer_Err:
-    Call TraceError(Err.Number, Err.Description, "frmMain.HoraFantasia_Timer", Erl)
-End Sub
+'Private Sub HoraFantasia_Timer()
+'        
+'    On Error GoTo HoraFantasia_Timer_Err
+'    If Lloviendo Then
+'        Label6.Caption = "Lloviendo"
+'    Else
+'        Label6.Caption = "No llueve"
+'    End If
+'
+'    If ServidorNublado Then
+'        Label7.Caption = "Nublado"
+'    Else
+'        Label7.Caption = "Sin nubes"
+'    End If
+'    frmMain.Label4.Caption = GetTimeFormated
+'    Exit Sub
+'HoraFantasia_Timer_Err:
+'    Call TraceError(Err.Number, Err.Description, "frmMain.HoraFantasia_Timer", Erl)
+'End Sub
 
 
 Private Sub mnuCerrar_Click()


### PR DESCRIPTION
Antes:
Si en objs.dat tu NumObjs=3675, pero en la DB tenés una fila con item_id=4000 esas funciones crashean y el personaje no carga.

Ahora:
Si pasa eso, ignora el item_id de esa fila y no lo carga, hace como si no tuvieses ningún item en ese slot.