### PR TITLE
Nueva restriccion de mapa solo para grupos

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2827,6 +2827,7 @@ Type t_MapInfo
     MaxLevel As Integer
     Salida As t_WorldPos
     NoMascotas As Boolean
+    OnlyGroups As Boolean
     DropItems As Boolean
     SafeFightMap As Boolean
     FriendlyFire As Boolean

--- a/Codigo/FileIO.bas
+++ b/Codigo/FileIO.bas
@@ -2139,6 +2139,7 @@ Public Sub CargarMapaFormatoCSM(ByVal map As Long, ByVal MAPFl As String)
 356     MapInfo(map).SinInviOcul = (val(MapDat.restrict_mode) And 16) <> 0
 358     MapInfo(map).SoloClanes = (val(MapDat.restrict_mode) And 32) <> 0
 359     MapInfo(map).NoMascotas = (val(MapDat.restrict_mode) And 64) <> 0
+        MapInfo(Map).OnlyGroups = (val(MapDat.restrict_mode) And 128) <> 0
 360     MapInfo(map).ResuCiudad = val(GetVar(DatPath & "Map.dat", "RESUCIUDAD", map)) <> 0
 362     MapInfo(map).letter_grh = MapDat.letter_grh
 364     MapInfo(map).lluvia = MapDat.lluvia

--- a/Codigo/GameLogic.bas
+++ b/Codigo/GameLogic.bas
@@ -329,8 +329,16 @@ Private Function CheckMapRestrictions(ByVal UserIndex As Integer, ByVal Map As I
                 End If
                 Exit Function
             End If
+            
+153         If MapInfo(Map).OnlyGroups And .Grupo.EnGrupo Then
+154             If .flags.UltimoMensaje <> 107 Then
+155                 Call WriteConsoleMsg(UserIndex, "Necesitas pertenecer a un grupo para entrar a este mapa.", e_FontTypeNames.FONTTYPE_INFO)
+156                 .flags.UltimoMensaje = 107
+                End If
+                Exit Function
+            End If
 
-154         CheckMapRestrictions = True
+157         CheckMapRestrictions = True
 
         End With
 
@@ -433,7 +441,6 @@ Public Sub DoTileEvents(ByVal UserIndex As Integer, ByVal Map As Integer, ByVal 
                         Else
 156                         Call ClosestLegalPos(destPos, nPos)
                         End If
-                        
                         
 158                     If nPos.X <> 0 And nPos.y <> 0 Then
 160                         Call WarpUserChar(UserIndex, nPos.map, nPos.X, nPos.y, EsTeleport)

--- a/Codigo/GameLogic.bas
+++ b/Codigo/GameLogic.bas
@@ -330,7 +330,7 @@ Private Function CheckMapRestrictions(ByVal UserIndex As Integer, ByVal Map As I
                 Exit Function
             End If
             
-153         If MapInfo(Map).OnlyGroups And .Grupo.EnGrupo Then
+153         If MapInfo(Map).OnlyGroups And Not .Grupo.EnGrupo Then
 154             If .flags.UltimoMensaje <> 107 Then
 155                 Call WriteConsoleMsg(UserIndex, "Necesitas pertenecer a un grupo para entrar a este mapa.", e_FontTypeNames.FONTTYPE_INFO)
 156                 .flags.UltimoMensaje = 107

--- a/Codigo/ModGrupos.bas
+++ b/Codigo/ModGrupos.bas
@@ -192,6 +192,12 @@ Public Sub EcharMiembro(ByVal UserIndex As Integer, ByVal Indice As Byte)
 154         Call SetUserRef(.Grupo.Miembros(1), 0)
 156         Call RefreshCharStatus(UserIndexEchar)
             .Grupo.ID = -1
+            
+            If MapInfo(.pos.Map).Salida.Map <> 0 Then
+                Call WriteConsoleMsg(UserIndex, "Debes estar en un grupo para permanecer en este mapa.", e_FontTypeNames.FONTTYPE_INFO)
+                Call WarpUserChar(UserIndex, MapInfo(.pos.Map).Salida.Map, MapInfo(.pos.Map).Salida.x, MapInfo(.pos.Map).Salida.y, True)
+            End If
+            
         End With
     
                             
@@ -280,6 +286,12 @@ Public Sub SalirDeGrupo(ByVal UserIndex As Integer)
 156         Call SetUserRef(.Grupo.Lider, 0)
             
             Call modSendData.SendData(ToIndex, UserIndex, PrepareUpdateGroupInfo(UserIndex))
+            
+            If MapInfo(.pos.Map).Salida.Map <> 0 Then
+                Call WriteConsoleMsg(UserIndex, "Debes estar en un grupo para permanecer en este mapa.", e_FontTypeNames.FONTTYPE_INFO)
+                Call WarpUserChar(UserIndex, MapInfo(.pos.Map).Salida.Map, MapInfo(.pos.Map).Salida.x, MapInfo(.pos.Map).Salida.y, True)
+            End If
+            
         End With
     
 158     Call RefreshCharStatus(UserIndex)
@@ -336,6 +348,12 @@ Public Sub SalirDeGrupoForzado(ByVal UserIndex As Integer)
                 UserList(.Grupo.Lider.ArrayIndex).Grupo.ID = -1
 146             Call RefreshCharStatus(.Grupo.Lider.ArrayIndex)
             End If
+            
+            If MapInfo(.pos.Map).Salida.Map <> 0 Then
+                Call WriteConsoleMsg(UserIndex, "Debes estar en un grupo para permanecer en este mapa.", e_FontTypeNames.FONTTYPE_INFO)
+                Call WarpUserChar(UserIndex, MapInfo(.pos.Map).Salida.Map, MapInfo(.pos.Map).Salida.x, MapInfo(.pos.Map).Salida.y, True)
+            End If
+            
         End With
         Exit Sub
 SalirDeGrupoForzado_Err:
@@ -359,6 +377,10 @@ On Error GoTo FinalizarGrupo_Err
 118             .Grupo.EnGrupo = False
                 .Grupo.ID = -1
                 Call modSendData.SendData(ToIndex, .Grupo.Miembros(i).ArrayIndex, PrepareUpdateGroupInfo(.Grupo.Miembros(i).ArrayIndex))
+                If MapInfo(.pos.Map).Salida.Map <> 0 Then
+                    Call WriteConsoleMsg(UserIndex, "Debes estar en un grupo para permanecer en este mapa.", e_FontTypeNames.FONTTYPE_INFO)
+                    Call WarpUserChar(UserIndex, MapInfo(.pos.Map).Salida.Map, MapInfo(.pos.Map).Salida.x, MapInfo(.pos.Map).Salida.y, True)
+                End If
 120         Next i
         End With
         Exit Sub


### PR DESCRIPTION
Si un usuario no pertenece a un grupo, no va a poder entrar al mapa.
Si un usuario sale del grupo o es expulsado del mismo estando en un mapa con esta restricción y dicho mapa tiene coordenadas de salida, este será teletransportado a la misma.

Esto se debe usar en conjunto con esto:
https://github.com/ao-org/argentum20-worldeditor/pull/2

Closes #455 