### PR TITLE
Fix abandonar party te saca del mapa

### DIFF
--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -3368,6 +3368,9 @@ Private Sub HandleWorkLeftClick(ByVal UserIndex As Integer)
                     End If
 
 616             Case e_Skill.Grupo
+
+617                 Call LookatTile(UserIndex, .Pos.map, X, Y)
+
                     'Target whatever is in that tile
 618                 tU = .flags.targetUser.ArrayIndex
                     
@@ -9086,31 +9089,15 @@ Private Sub HandleAbandonarGrupo(ByVal UserIndex As Integer)
         On Error GoTo HandleAbandonarGrupo_Err
 
 100     With UserList(UserIndex)
-
         
 102         Call Reader.ReadInt16
         
 104         If UserList(userIndex).Grupo.Lider.ArrayIndex = userIndex Then
-            
 106             Call FinalizarGrupo(UserIndex)
-
-                Dim i As Byte
-            
-108             For i = 2 To UserList(UserIndex).Grupo.CantidadMiembros
-110                 Call WriteUbicacion(UserIndex, i, 0)
-112             Next i
-
-114             UserList(UserIndex).Grupo.CantidadMiembros = 0
-116             UserList(UserIndex).Grupo.EnGrupo = False
-                UserList(UserIndex).Grupo.Id = -1
-118             Call SetUserRef(UserList(userIndex).Grupo.Lider, 0)
-120             Call SetUserRef(UserList(userIndex).Grupo.PropuestaDe, 0)
-122             Call WriteConsoleMsg(UserIndex, "Has disuelto el grupo.", e_FontTypeNames.FONTTYPE_INFOIAO)
-124             Call RefreshCharStatus(UserIndex)
-                Call modSendData.SendData(ToIndex, UserIndex, PrepareUpdateGroupInfo(UserIndex))
             Else
 126             Call SalirDeGrupo(UserIndex)
             End If
+
         End With
         Exit Sub
 

--- a/Codigo/TCP.bas
+++ b/Codigo/TCP.bas
@@ -1622,13 +1622,14 @@ Sub ResetUserSlot(ByVal UserIndex As Integer)
         With UserList(UserIndex)
 100         .ConnectionDetails.ConnIDValida = False
 102         .ConnectionDetails.ConnID = 0
-113         .Stats.Shield = 0
-104         If .Grupo.Lider.ArrayIndex = UserIndex Then
-106             Call FinalizarGrupo(UserIndex)
-            End If
+104         .Stats.Shield = 0
 
-108         If .Grupo.EnGrupo Then
-110             Call SalirDeGrupoForzado(UserIndex)
+106         If .Grupo.EnGrupo Then
+108             If .Grupo.Lider.ArrayIndex = UserIndex Then
+110                 Call FinalizarGrupo(UserIndex)
+                Else
+111                 Call SalirDeGrupoForzado(UserIndex)
+                End If
             End If
         
             If m_NameIndex.Exists(UCase(.name)) Then


### PR DESCRIPTION
Arreglo error introducido en PR #503.
Producía que al salir de grupo en algunos mapas te llevaba afuera (aún sin tener habilitado que sea un mapa solo mapa grupos).
También arreglo un poco el sistema, ya que había casos en los que el lider quedaba dentro igual.
También arreglo el invitar a grupo, que no funcionaba a la primera (faltaba un LookAtTile).
Queda mucho código repetido en el código que finaliza el grupo al salir los miembros, pero lo dejo para mejorar más adelante.