### PR TITLE
Fix seguro NPC

### DIFF
--- a/Codigo/AI_NPC.bas
+++ b/Codigo/AI_NPC.bas
@@ -600,9 +600,7 @@ Private Sub AI_AtacarUsuarioObjetivo(ByVal AtackerNpcIndex As Integer)
                     Call AnimacionIdle(AtackerNpcIndex, True)
                     If UserIndexFront > 0 Then
                         If UserList(UserIndexFront).flags.Muerto = 0 Then
-                            If UserList(UserIndexFront).Faccion.Status = 1 And (.NPCtype = e_NPCType.GuardiaReal) Then
-                                
-                            Else
+                            If EsEnemigo(AtackerNpcIndex, UserIndexFront) Then
                                 Call NpcAtacaUser(AtackerNpcIndex, UserIndexFront, tHeading)
                             End If
                         End If
@@ -1281,22 +1279,26 @@ Private Function EsEnemigo(ByVal NpcIndex As Integer, ByVal UserIndex As Integer
 
 100     If NpcIndex = 0 Or UserIndex = 0 Then Exit Function
 
-102     With NpcList(NpcIndex)
+        EsEnemigo = True
 
+102     With NpcList(NpcIndex)
+            ' Si el NPC tiene un atacante
 104         If .flags.AttackedBy <> vbNullString Then
+                ' Si el usuario actual es el atacante
 106             EsEnemigo = (UserIndex = NameIndex(.flags.AttackedBy).ArrayIndex)
 108             If EsEnemigo Then Exit Function
+                ' Si no es el atacante, preguntamos si el NPC puede atacarlo
+109             EsEnemigo = CanAttackNotOwner(NpcIndex, UserIndex)
             End If
 
 110         Select Case .flags.AIAlineacion
                 Case e_Alineacion.Real
-112                 EsEnemigo = (Status(UserIndex) Mod 2) <> 1
+112                 EsEnemigo = EsEnemigo And (Status(UserIndex) Mod 2) <> 1
 
 114             Case e_Alineacion.Caos
-116                 EsEnemigo = (Status(UserIndex) Mod 2) <> 0
+116                 EsEnemigo = EsEnemigo And (Status(UserIndex) Mod 2) <> 0
 
 118             Case e_Alineacion.ninguna
-120                 EsEnemigo = True
                     ' Ok. No hay nada especial para hacer, cualquiera puede ser enemigo!
 
             End Select

--- a/Codigo/Admin.bas
+++ b/Codigo/Admin.bas
@@ -93,6 +93,7 @@ Public IntervaloMagiaGolpe          As Long
 Public IntervaloGolpeMagia          As Long
 Public IntervaloUserPuedeCastear    As Long
 Public IntervaloTrabajarExtraer     As Long
+Public IntervaloNpcOwner            As Long
 
 Public IntervaloTrabajarConstruir   As Long
 

--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2553,6 +2553,7 @@ Public Type t_NPCFlags
     ' UseAINow As Boolean No se usa, borrar de la DB!!!!
     Sound As Integer
     AttackedBy As String
+    AttackedTime As Long
     AttackedFirstBy As String
     backup As Byte
     RespawnOrigPos As Byte

--- a/Codigo/EffectProvoked.cls
+++ b/Codigo/EffectProvoked.cls
@@ -68,6 +68,7 @@ Public Sub Setup(ByVal SourceIndex As Integer, ByVal SourceType As e_ReferenceTy
         If SourceType = eUser Then
             Call SetUserRef(NpcList(TargetIndex).TargetUser, SourceIndex)
             NpcList(TargetIndex).flags.AttackedBy = UserList(SourceIndex).name
+            NpcList(TargetIndex).flags.AttackedTime = GetTickCount
         Else
             Call SetNpcRef(NpcList(TargetIndex).TargetNPC, SourceIndex)
         End If

--- a/Codigo/FileIO.bas
+++ b/Codigo/FileIO.bas
@@ -2701,6 +2701,7 @@ Sub LoadIntervalos()
         'TODO : Agregar estos intervalos al form!!!
 206     IntervaloMagiaGolpe = val(Lector.GetValue("INTERVALOS", "IntervaloMagiaGolpe"))
 208     IntervaloGolpeMagia = val(Lector.GetValue("INTERVALOS", "IntervaloGolpeMagia"))
+209     IntervaloNpcOwner = val(Lector.GetValue("INTERVALOS", "IntervaloNpcOwner", "10000"))
     
         'frmMain.tLluvia.Interval = val(Lector.GetValue("INTERVALOS", "IntervaloPerdidaStaminaLluvia"))
         'FrmInterv.txtIntervaloPerdidaStaminaLluvia.Text = frmMain.tLluvia.Interval

--- a/Codigo/FrmInterv.frm
+++ b/Codigo/FrmInterv.frm
@@ -896,6 +896,7 @@ Private Sub Command2_Click()
 140     Call WriteVar(IniPath & "intervalo.ini", "INTERVALOS", "IntervaloTrabajarExtraer", CStr(IntervaloTrabajarExtraer))
 142     Call WriteVar(IniPath & "intervalo.ini", "INTERVALOS", "IntervaloTrabajarConstruir", CStr(IntervaloTrabajarConstruir))
 144     Call WriteVar(IniPath & "intervalo.ini", "INTERVALOS", "IntervaloUserPuedeAtacar", CStr(IntervaloUserPuedeAtacar))
+145     Call WriteVar(IniPath & "intervalo.ini", "INTERVALOS", "IntervaloNpcOwner", CStr(IntervaloNpcOwner))
         'Call WriteVar(IniPath & "intervalo.ini", "INTERVALOS", "IntervaloPerdidaStaminaLluvia", frmMain.tLluvia.Interval)
 
 146     MsgBox "Los intervalos se han guardado sin problemas"

--- a/Codigo/GameLogic.bas
+++ b/Codigo/GameLogic.bas
@@ -1587,6 +1587,10 @@ Sub LookatTile(ByVal UserIndex As Integer, ByVal Map As Integer, ByVal X As Inte
                     End If
 
                 End If
+
+                If EsGM(UserIndex) And GetOwnedBy(TempCharIndex) <> 0 Then
+                    estatus = estatus & " | Owned by " & NpcList(TempCharIndex).flags.AttackedBy
+                End If
                         
 456             estatus = estatus & ">"
     

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1934,7 +1934,10 @@ Sub NPCAtacado(ByVal NpcIndex As Integer, ByVal UserIndex As Integer, Optional B
 104     If Not IsSet(NpcList(npcIndex).flags.StatusMask, eTaunted) And NpcList(npcIndex).Movement <> Estatico And NpcList(npcIndex).flags.AttackedFirstBy = vbNullString Then
 106         Call SetUserRef(NpcList(npcIndex).TargetUser, UserIndex)
 108         NpcList(NpcIndex).Hostile = 1
-110         If AffectsOwner Then NpcList(NpcIndex).flags.AttackedBy = UserList(UserIndex).name
+110         If AffectsOwner Then
+                NpcList(NpcIndex).flags.AttackedBy = UserList(UserIndex).name
+                NpcList(NpcIndex).flags.AttackedTime = GetTickCount
+            End If
         End If
         
         'Guarda el NPC que estas atacando ahora.

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -3294,7 +3294,7 @@ Private Sub HandleWorkLeftClick(ByVal UserIndex As Integer)
                                 Exit Sub
                             End If
                             
-564                         If LenB(NpcList(tN).flags.AttackedBy) <> 0 Then
+564                         If GetOwnedBy(tN) <> 0 Then
 566                             Call WriteConsoleMsg(UserIndex, "No puedes domar una criatura que esta luchando con un jugador.", e_FontTypeNames.FONTTYPE_INFO)
                                 Exit Sub
                             End If

--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -2081,6 +2081,7 @@ Sub AllMascotasAtacanUser(ByVal victim As Integer, ByVal Maestro As Integer)
                     If IsValidNpcRef(.MascotasIndex(iCount)) Then
 108                     If IsSet(NpcList(mascotaIndex).flags.BehaviorFlags, e_BehaviorFlags.eAttackUsers) Then
 110                         NpcList(mascotaIndex).flags.AttackedBy = UserList(victim).Name
+111                         NpcList(mascotaIndex).flags.AttackedTime = GetTickCount
 112                         Call SetUserRef(NpcList(mascotaIndex).TargetUser, victim)
 114                         Call SetMovement(mascotaIndex, e_TipoAI.NpcDefensa)
 116                         NpcList(mascotaIndex).Hostile = 0
@@ -2126,6 +2127,7 @@ Public Sub AllMascotasAtacanNPC(ByVal NpcIndex As Integer, ByVal UserIndex As In
 110                         Call SetNpcRef(.TargetNPC, NpcIndex)
 112                         Call SetMovement(mascotaIdx, e_TipoAI.NpcAtacaNpc)
                             NpcList(NpcIndex).flags.AttackedBy = UserList(UserIndex).name
+                            NpcList(NpcIndex).flags.AttackedTime = GetTickCount
                             Call SetNpcRef(UserList(UserIndex).flags.NPCAtacado, NpcIndex)
                         End If
                     End With

--- a/Codigo/clsIniManager.cls
+++ b/Codigo/clsIniManager.cls
@@ -371,9 +371,10 @@ End Sub
 '
 ' @param    Main The name of the main section in which we will be searching.
 ' @param    key The key of the value we are looking for.
+' @param    DefaultValue Default value if key is not found.
 ' @returns  The value asociated with the given key under the requeted main section of the INI file or a null string if it's not found.
 
-Public Function GetValue(ByVal Main As String, ByVal Key As String)
+Public Function GetValue(ByVal Main As String, ByVal key As String, Optional ByVal DefaultValue As String = "") As String
     
     On Error GoTo GetValue_Err
     
@@ -385,7 +386,6 @@ Public Function GetValue(ByVal Main As String, ByVal Key As String)
     '**************************************************************
     Dim i As Long
     Dim j As Long
-    Dim retval As String
     
     'Search for the main node
     i = FindMain(UCase$(Main))
@@ -396,9 +396,11 @@ Public Function GetValue(ByVal Main As String, ByVal Key As String)
         j = FindKey(fileData(i), UCase$(Key))
         
         'If we found it we return it
-        If j >= 0 Then retval = fileData(i).values(j).Value
-
-        GetValue = retval
+        If j >= 0 Then
+            GetValue = fileData(i).values(j).Value
+        Else
+            GetValue = DefaultValue
+        End If
 
     End If
 

--- a/intervalos.ini
+++ b/intervalos.ini
@@ -17,6 +17,7 @@ IntervaloFrio=75
 IntervaloWAVFX=190
 IntervaloMover=200
 IntervaloNpcAI=150
+IntervaloNpcOwner=10000
 IntervaloTrabajarExtraer=3000
 IntervaloTrabajarConstruir=500
 IntervaloWS=180 'Cantidad de minutos


### PR DESCRIPTION
Fixes #514

Se elimina el chequeo de distancia para ser "dueño" de un NPC.
Tenía un bug fácil de arreglar pero charlando con los game master pensamos que sería mejor otra estrategia.

Ahora es por tiempo: 10 segundos (por defecto) desde el último ataque.
Esto es configurable desde intervalos.ini Igualmente al irte del rango de visión del NPC dejás de ser el dueño. 

Arreglé otro errorcito que si pasabas por al lado de un NPC que tenía dueño, ignoraba todas las validaciones y te golpeaba igual.