### PR TITLE
Fix error introducido en PR de seguro NPC

### DIFF
--- a/Codigo/EffectProvoked.cls
+++ b/Codigo/EffectProvoked.cls
@@ -68,7 +68,7 @@ Public Sub Setup(ByVal SourceIndex As Integer, ByVal SourceType As e_ReferenceTy
         If SourceType = eUser Then
             Call SetUserRef(NpcList(TargetIndex).TargetUser, SourceIndex)
             NpcList(TargetIndex).flags.AttackedBy = UserList(SourceIndex).name
-            NpcList(TargetIndex).flags.AttackedTime = GetTickCount
+            NpcList(TargetIndex).flags.AttackedTime = GlobalFrameTime
         Else
             Call SetNpcRef(NpcList(TargetIndex).TargetNPC, SourceIndex)
         End If

--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -2398,7 +2398,7 @@ Public Function CanAttackNotOwner(ByVal NpcIndex As Integer, ByVal UserIndex As 
     ' Si el usuario puede atacar al NPC
     If AttackResult.CanAttack Then
         ' Lo atacamos solo si puede atacar sin hacerse PK (no lo forzamos a hacerse PK)
-        CanAttackNotOwner = AttackResult.TurnPK
+        CanAttackNotOwner = Not AttackResult.TurnPK
     Else
         ' En caso que el usuario no pueda atacar al NPC, este debe ignorarlo a el
         ' Excepto que no pueda atacar por los siguientes motivos: esta montado, esta fuera de su campo de vision

--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -1675,7 +1675,7 @@ Sub DoFollow(ByVal NpcIndex As Integer, ByVal UserName As String)
                 player = NameIndex(username)
                 If IsValidUserRef(player) Then
 114                 .flags.AttackedBy = username
-115                 .flags.AttackedTime = GetTickCount
+115                 .flags.AttackedTime = GlobalFrameTime
 116                 .targetUser = player
 118                 .flags.Follow = True
 120                 Call SetMovement(NpcIndex, e_TipoAI.NpcDefensa)
@@ -2383,7 +2383,7 @@ Public Function GetOwnedBy(ByVal NpcIndex As Integer) As Integer
     GetOwnedBy = 0
     With NpcList(NpcIndex).flags
         If .AttackedBy = vbNullString Then Exit Function
-        If GetTickCount - .AttackedTime > IntervaloNpcOwner Then Exit Function
+        If GlobalFrameTime - .AttackedTime > IntervaloNpcOwner Then Exit Function
         Dim Attacker As t_UserReference: Attacker = NameIndex(.AttackedBy)
         If Not IsValidUserRef(Attacker) Then Exit Function
         GetOwnedBy = Attacker.ArrayIndex

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1936,7 +1936,7 @@ Sub NPCAtacado(ByVal NpcIndex As Integer, ByVal UserIndex As Integer, Optional B
 108         NpcList(NpcIndex).Hostile = 1
 110         If AffectsOwner Then
                 NpcList(NpcIndex).flags.AttackedBy = UserList(UserIndex).name
-                NpcList(NpcIndex).flags.AttackedTime = GetTickCount
+                NpcList(NpcIndex).flags.AttackedTime = GlobalFrameTime
             End If
         End If
         

--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -2081,7 +2081,7 @@ Sub AllMascotasAtacanUser(ByVal victim As Integer, ByVal Maestro As Integer)
                     If IsValidNpcRef(.MascotasIndex(iCount)) Then
 108                     If IsSet(NpcList(mascotaIndex).flags.BehaviorFlags, e_BehaviorFlags.eAttackUsers) Then
 110                         NpcList(mascotaIndex).flags.AttackedBy = UserList(victim).Name
-111                         NpcList(mascotaIndex).flags.AttackedTime = GetTickCount
+111                         NpcList(mascotaIndex).flags.AttackedTime = GlobalFrameTime
 112                         Call SetUserRef(NpcList(mascotaIndex).TargetUser, victim)
 114                         Call SetMovement(mascotaIndex, e_TipoAI.NpcDefensa)
 116                         NpcList(mascotaIndex).Hostile = 0
@@ -2127,7 +2127,7 @@ Public Sub AllMascotasAtacanNPC(ByVal NpcIndex As Integer, ByVal UserIndex As In
 110                         Call SetNpcRef(.TargetNPC, NpcIndex)
 112                         Call SetMovement(mascotaIdx, e_TipoAI.NpcAtacaNpc)
                             NpcList(NpcIndex).flags.AttackedBy = UserList(UserIndex).name
-                            NpcList(NpcIndex).flags.AttackedTime = GetTickCount
+                            NpcList(NpcIndex).flags.AttackedTime = GlobalFrameTime
                             Call SetNpcRef(UserList(UserIndex).flags.NPCAtacado, NpcIndex)
                         End If
                     End With


### PR DESCRIPTION
La condición estaba invertida. Producía que los NPC no ataquen a otros usuarios cuando están inmovilizados.