### PR TITLE
Fix invisibilidad

### DIFF
--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1544,7 +1544,7 @@ Function MoveUserChar(ByVal UserIndex As Integer, ByVal nHeading As e_Heading) A
                         .flags.stepToggle = Not .flags.stepToggle
                         
                         If Not EsGM(UserIndex) Then
-                            If .flags.invisible + .flags.Oculto > 0 Then
+                            If .flags.invisible + .flags.Oculto > 0 And .flags.Navegando = 0 Then
                                 For LoopC = 1 To ConnGroups(UserList(UserIndex).pos.Map).CountEntrys
                                     tempIndex = ConnGroups(UserList(UserIndex).pos.Map).UserEntrys(LoopC)
                                     If tempIndex <> UserIndex Then
@@ -1552,11 +1552,18 @@ Function MoveUserChar(ByVal UserIndex As Integer, ByVal nHeading As e_Heading) A
                                             If UserList(tempIndex).AreasInfo.AreaReciveY And UserList(UserIndex).AreasInfo.AreaPerteneceY Then
                                                 If UserList(tempIndex).ConnectionDetails.ConnIDValida Then
                                                     If UserList(tempIndex).flags.Muerto = 0 Or MapInfo(UserList(tempIndex).pos.Map).Seguro = 1 Then
-                                                        If Distancia(nPos, UserList(tempIndex).pos) > DISTANCIA_ENVIO_DATOS And .Counters.timeFx + .Counters.timeChat = 0 Then
-                                                            If Abs(nPos.X - UserList(tempIndex).pos.X) <= RANGO_VISION_X And Abs(nPos.y - UserList(tempIndex).pos.y) <= RANGO_VISION_Y Then
-                                                                'Mandamos los pasos para los pjs q estan lejos para que simule que caminen.
-                                                                Call WritePlayWaveStep(tempIndex, MapData(nPos.Map, nPos.X, nPos.y).Graphic(1), MapData(nPos.Map, nPos.X, nPos.y).Graphic(2), Abs(nPos.X - UserList(tempIndex).pos.X) + Abs(nPos.y - UserList(tempIndex).pos.y), _
-                                                                                             Sgn(nPos.X - UserList(tempIndex).pos.X), .flags.stepToggle)
+                                                        If .GuildIndex = 0 Or .GuildIndex <> UserList(tempIndex).GuildIndex Or modGuilds.NivelDeClan(.GuildIndex) < 6 Then
+                                                            If .Counters.timeFx + .Counters.timeChat = 0 Then
+                                                                If Distancia(nPos, UserList(tempIndex).Pos) > DISTANCIA_ENVIO_DATOS Then
+                                                                    'Mandamos los pasos para los pjs q estan lejos para que simule que caminen.
+                                                                    'Mando tambien el char para q lo borre
+                                                                    Call WritePlayWaveStep(tempIndex, .Char.CharIndex, _
+                                                                        MapData(nPos.map, nPos.X, nPos.Y).Graphic(1), MapData(nPos.map, nPos.X, nPos.Y).Graphic(2), _
+                                                                        Distance(nPos.X, nPos.Y, UserList(tempIndex).Pos.X, UserList(tempIndex).Pos.Y), _
+                                                                        Sgn(nPos.X - UserList(tempIndex).Pos.X), .flags.stepToggle)
+                                                                Else
+                                                                    Call WritePosUpdateChar(tempIndex, nPos.X, nPos.Y, .Char.CharIndex)
+                                                                End If
                                                             End If
                                                         End If
                                                     End If
@@ -1571,9 +1578,10 @@ Function MoveUserChar(ByVal UserIndex As Integer, ByVal nHeading As e_Heading) A
                             'Esto es para q si me acerco a un usuario que esta invisible y no se mueve me notifique su posicion
                             For X = nPos.X - DISTANCIA_ENVIO_DATOS To nPos.X + DISTANCIA_ENVIO_DATOS
                                 For y = nPos.y - DISTANCIA_ENVIO_DATOS To nPos.y + DISTANCIA_ENVIO_DATOS
-                                    If MapData(.Pos.map, X, y).UserIndex > 0 And MapData(.Pos.map, X, y).UserIndex <> UserIndex Then
-                                        If UserList(MapData(.Pos.map, X, y).UserIndex).flags.invisible + UserList(MapData(.Pos.map, X, y).UserIndex).flags.Oculto > 0 And (UserList(MapData(.Pos.map, X, y).UserIndex).GuildIndex <> UserList(UserIndex).GuildIndex Or UserList(UserIndex).GuildIndex = 0) Then
-                                            Call WritePosUpdateChar(UserIndex, X, y, UserList(MapData(.Pos.map, X, y).UserIndex).Char.charindex)
+                                    tempIndex = MapData(.Pos.map, X, y).UserIndex
+                                    If tempIndex > 0 And tempIndex <> UserIndex Then
+                                        If UserList(tempIndex).flags.invisible + UserList(tempIndex).flags.Oculto > 0 And UserList(tempIndex).flags.Navegando = 0 And (.GuildIndex = 0 Or .GuildIndex <> UserList(tempIndex).GuildIndex Or modGuilds.NivelDeClan(.GuildIndex) < 6) Then
+                                            Call WritePosUpdateChar(UserIndex, X, y, UserList(tempIndex).Char.charindex)
                                         End If
                                     End If
                                 Next y

--- a/Codigo/Protocol_Writes.bas
+++ b/Codigo/Protocol_Writes.bas
@@ -1568,6 +1568,7 @@ WritePlayWave_Err:
         '</EhFooter>
 End Sub
 Public Sub WritePlayWaveStep(ByVal UserIndex As Integer, _
+                         ByVal CharIndex As Integer, _
                          ByVal grh As Long, _
                          ByVal grh2 As Long, _
                          ByVal distance As Byte, _
@@ -1577,8 +1578,9 @@ Public Sub WritePlayWaveStep(ByVal UserIndex As Integer, _
         On Error GoTo WritePlayWaveStep_Err
         '</EhHeader>
 100     Call Writer.WriteInt16(ServerPacketID.ePlayWaveStep)
-102     Call Writer.WriteInt32(grh)
-        Call Writer.WriteInt32(grh2)
+102     Call Writer.WriteInt16(CharIndex)
+104     Call Writer.WriteInt32(grh)
+106     Call Writer.WriteInt32(grh2)
 108     Call Writer.WriteInt8(distance)
 109     Call Writer.WriteInt16(balance)
 110     Call Writer.WriteBool(step)


### PR DESCRIPTION
Fix #465 y fix #518

Varios cambios acá. Principalmente las validaciones para enviar los personajes invisibles al cliente no eran las mismas en los dos lados que se usan. Queda pendiente reescribirlo mejor esto algún día.
Si un usuario invisible se alejaba de otro usuario, debe borrarse el char en el cliente. Esto no funcionaba.
Faltaba también controlar el caso que un usuario se mueva cerca de otro estando invisible. Es necesario mandar paquetes al cliente acá para que no se quede bloqueado en una posición.

Esto va mergeado con un PR en el cliente que se llama igual. Mergear ambos a la vez ya que hay cambios de paquetes.