### PR TITLE
Fix invi 2

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2135,6 +2135,7 @@ Public Type t_UserCounters
     
     timeChat As Integer
     timeFx As Integer
+    timeGuildChat As Integer
     
     IdleCount As Integer
     AttackCounter As Integer

--- a/Codigo/GameLogic.bas
+++ b/Codigo/GameLogic.bas
@@ -2061,7 +2061,7 @@ Public Sub ResucitarOCurar(ByVal UserIndex As Integer)
         
         Call SendData(SendTarget.ToPCArea, UserIndex, PrepareMessagePlayWave(20, UserList(UserIndex).Pos.X, UserList(UserIndex).Pos.Y))
     
-        UserList(UserIndex).Counters.timeFx = 2
+        UserList(UserIndex).Counters.timeFx = 3
         Call SendData(SendTarget.ToPCArea, UserIndex, PrepareMessageCreateFX(UserList(UserIndex).Char.charindex, 35, 1, UserList(UserIndex).Pos.X, UserList(UserIndex).Pos.Y))
     
         
@@ -2072,7 +2072,7 @@ Public Sub ResucitarOCurar(ByVal UserIndex As Integer)
             
         Call WriteUpdateHP(UserIndex)
         
-        UserList(UserIndex).Counters.timeFx = 2
+        UserList(UserIndex).Counters.timeFx = 3
         Call SendData(SendTarget.ToPCArea, UserIndex, PrepareMessageCreateFX(UserList(UserIndex).Char.charindex, 9, 1, UserList(UserIndex).Pos.X, UserList(UserIndex).Pos.Y))
         Call SendData(SendTarget.ToPCArea, UserIndex, PrepareMessagePlayWave(18, UserList(UserIndex).Pos.X, UserList(UserIndex).Pos.Y))
     

--- a/Codigo/General.bas
+++ b/Codigo/General.bas
@@ -1511,7 +1511,7 @@ Public Sub EfectoVeneno(ByVal UserIndex As Integer)
 106         With UserList(UserIndex)
               'Call WriteConsoleMsg(UserIndex, "Estás envenenado, si no te curas morirás.", e_FontTypeNames.FONTTYPE_VENENO)
 108           Call WriteLocaleMsg(UserIndex, "47", e_FontTypeNames.FONTTYPE_VENENO)
-              UserList(userindex).Counters.timeFx = 2
+              UserList(userindex).Counters.timeFx = 3
 110           Call SendData(SendTarget.ToPCAliveArea, userindex, PrepareMessageParticleFX(.Char.charindex, e_ParticulasIndex.Envenena, 30, False, , UserList(userindex).Pos.X, UserList(userindex).Pos.y))
 112           .Counters.Veneno = 0
               ' El veneno saca un porcentaje de vida random.
@@ -1542,7 +1542,7 @@ Public Sub EfectoIncineramiento(ByVal UserIndex As Integer)
 102             If .Counters.Incineracion Mod (IntervaloIncineracion \ 5) = 0 Then
                     ' "Te estás incinerando, si no te curas morirás.
 104                 Call WriteLocaleMsg(UserIndex, "392", e_FontTypeNames.FONTTYPE_FIGHT)
-                    UserList(userindex).Counters.timeFx = 2
+                    UserList(userindex).Counters.timeFx = 3
 106                 Damage = RandomNumber(35, 45)
 108                 Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessageCreateFX(.Char.charindex, 73, 0, .pos.x, .pos.y))
 112                 If .ChatCombate = 1 Then
@@ -1775,6 +1775,9 @@ Sub PasarSegundo()
                         .Counters.timeFx = .Counters.timeFx - 1
                     End If
                     
+                    If .Counters.timeGuildChat > 0 Then
+                        .Counters.timeGuildChat = .Counters.timeGuildChat - 1
+                    End If
                                       
 116                 If .flags.Silenciado = 1 Then
 118                     .flags.SegundosPasados = .flags.SegundosPasados + 1

--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -2195,7 +2195,7 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
 444                         Call ChangeUserChar(UserIndex, .Char.body, CabezaFinal, .Char.Heading, .Char.WeaponAnim, .Char.ShieldAnim, .Char.CascoAnim, .Char.CartAnim)
                             'Quitamos del inv el item
                             
-                            UserList(UserIndex).Counters.timeFx = 2
+                            UserList(UserIndex).Counters.timeFx = 3
 446                         Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessageCreateFX(.Char.charindex, 102, 0, UserList(UserIndex).Pos.X, UserList(UserIndex).Pos.Y))
     
 448                         If CabezaActual <> CabezaFinal Then
@@ -2275,7 +2275,7 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
 520                         .OrigChar.Head = CabezaFinal
 522                         Call ChangeUserChar(UserIndex, .Char.body, CabezaFinal, .Char.Heading, .Char.WeaponAnim, .Char.ShieldAnim, .Char.CascoAnim, .Char.CartAnim)
                             'Quitamos del inv el item
-                            UserList(UserIndex).Counters.timeFx = 2
+                            UserList(UserIndex).Counters.timeFx = 3
 524                         Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessageCreateFX(.Char.charindex, 102, 0, UserList(UserIndex).Pos.X, UserList(UserIndex).Pos.Y))
 526                         Call QuitarUserInvItem(UserIndex, Slot, 1)
     
@@ -2525,7 +2525,7 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
     
                             'Quitamos del inv el item
 876                         If CabezaActual <> CabezaFinal Then
-                                UserList(UserIndex).Counters.timeFx = 2
+                                UserList(UserIndex).Counters.timeFx = 3
 878                             Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessageCreateFX(.Char.charindex, 102, 0, UserList(UserIndex).Pos.X, UserList(UserIndex).Pos.Y))
 880                             Call SendData(SendTarget.toPCAliveArea, UserIndex, PrepareMessagePlayWave(obj.Snd1, .Pos.X, .Pos.y))
 882                             Call QuitarUserInvItem(UserIndex, Slot, 1)
@@ -2559,7 +2559,7 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
 904                             If sobrechar = 1 Then
 906                                 Call SendData(SendTarget.toPCAliveArea, UserIndex, PrepareMessageParticleFXToFloor(.Pos.X, .Pos.y, Particula, Tiempo))
                                 Else
-                                    UserList(UserIndex).Counters.timeFx = 2
+                                    UserList(UserIndex).Counters.timeFx = 3
 908                                 Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessageParticleFX(.Char.charindex, Particula, Tiempo, False, , UserList(UserIndex).Pos.X, UserList(UserIndex).Pos.Y))
                                 End If
     
@@ -2703,7 +2703,7 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
                           End If
             
 1018                 If obj.CreaFX <> 0 Then
-                        UserList(UserIndex).Counters.timeFx = 2
+                        UserList(UserIndex).Counters.timeFx = 3
 1020                    Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessageCreateFX(.Char.charindex, obj.CreaFX, 0, UserList(UserIndex).Pos.X, UserList(UserIndex).Pos.Y))
                      End If
             
@@ -3580,7 +3580,7 @@ Public Sub UseArpon(ByVal UserIndex As Integer)
         Dim Damage As Integer
         Damage = GetUserDamageWithItem(UserIndex, ObjIndex, 0)
         If TargetRef.RefType = eUser Then
-            UserList(TargetRef.ArrayIndex).Counters.timeFx = 2
+            UserList(TargetRef.ArrayIndex).Counters.timeFx = 3
             Call RemoveUserInvisibility(UserIndex)
             Call SendData(SendTarget.ToPCAliveArea, TargetRef.ArrayIndex, PrepareMessageCreateFX(UserList(TargetRef.ArrayIndex).Char.charindex, FXSANGRE, 0, UserList(TargetRef.ArrayIndex).pos.x, UserList(TargetRef.ArrayIndex).pos.y))
             Call SendData(SendTarget.ToPCAliveArea, TargetRef.ArrayIndex, PrepareMessagePlayWave(SND_IMPACTO, UserList(TargetRef.ArrayIndex).pos.x, UserList(TargetRef.ArrayIndex).pos.y))
@@ -3620,7 +3620,7 @@ Public Sub UseHandCannon(ByVal UserIndex As Integer, ByVal TileX As Integer, ByV
         Dim Tiempo    As Long
         Particula = val(ReadField(1, ObjData(ObjIndex).CreaParticula, Asc(":")))
         Tiempo = val(ReadField(2, ObjData(ObjIndex).CreaParticula, Asc(":")))
-        UserList(UserIndex).Counters.timeFx = 2
+        UserList(UserIndex).Counters.timeFx = 3
         Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessageParticleFX(UserList(UserIndex).Char.charindex, Particula, Tiempo, False, , UserList(UserIndex).pos.x, UserList(UserIndex).pos.y))
         Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareCreateProjectile(.pos.x, .pos.y, TileX, TileY, ObjData(ObjIndex).ProjectileType))
         Call CreateDelayedBlast(UserIndex, eUser, .pos.Map, TileX, TileY, ObjData(ObjIndex).ApplyEffectId, ObjIndex)

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1278,7 +1278,7 @@ Sub CheckUserLevel(ByVal UserIndex As Integer)
             
                 'Store it!
                 'Call Statistics.UserLevelUp(UserIndex)
-                UserList(userindex).Counters.timeFx = 2
+                UserList(userindex).Counters.timeFx = 3
 110             Call SendData(SendTarget.ToPCAliveArea, userindex, PrepareMessageCreateFX(.Char.charindex, 106, 0, .Pos.X, .Pos.y))
 112             Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessagePlayWave(SND_NIVEL, .Pos.X, .Pos.y))
 114             Call WriteLocaleMsg(UserIndex, "186", e_FontTypeNames.FONTTYPE_INFO)
@@ -1552,7 +1552,7 @@ Function MoveUserChar(ByVal UserIndex As Integer, ByVal nHeading As e_Heading) A
                                             If UserList(tempIndex).AreasInfo.AreaReciveY And UserList(UserIndex).AreasInfo.AreaPerteneceY Then
                                                 If UserList(tempIndex).ConnectionDetails.ConnIDValida Then
                                                     If UserList(tempIndex).flags.Muerto = 0 Or MapInfo(UserList(tempIndex).pos.Map).Seguro = 1 Then
-                                                        If .GuildIndex = 0 Or .GuildIndex <> UserList(tempIndex).GuildIndex Or modGuilds.NivelDeClan(.GuildIndex) < 6 Then
+                                                        If Not CheckGuildSend(UserList(UserIndex), UserList(tempIndex)) Then
                                                             If .Counters.timeFx + .Counters.timeChat = 0 Then
                                                                 If Distancia(nPos, UserList(tempIndex).Pos) > DISTANCIA_ENVIO_DATOS Then
                                                                     'Mandamos los pasos para los pjs q estan lejos para que simule que caminen.
@@ -2603,7 +2603,7 @@ Sub WarpUserChar(ByVal UserIndex As Integer, _
         
 206             If FX Then 'FX
 208                 Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessagePlayWave(SND_WARP, X, y))
-                    UserList(userindex).Counters.timeFx = 2
+                    UserList(userindex).Counters.timeFx = 3
 210                 Call SendData(SendTarget.ToPCAliveArea, userindex, PrepareMessageCreateFX(.Char.charindex, e_FXIDs.FXWARP, 0, .Pos.X, .Pos.y))
                 End If
 

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1547,23 +1547,21 @@ Function MoveUserChar(ByVal UserIndex As Integer, ByVal nHeading As e_Heading) A
                             If .flags.invisible + .flags.Oculto > 0 And .flags.Navegando = 0 Then
                                 For LoopC = 1 To ConnGroups(UserList(UserIndex).pos.Map).CountEntrys
                                     tempIndex = ConnGroups(UserList(UserIndex).pos.Map).UserEntrys(LoopC)
-                                    If tempIndex <> UserIndex Then
-                                        If UserList(tempIndex).AreasInfo.AreaReciveX And UserList(UserIndex).AreasInfo.AreaPerteneceX Then  'Esta en el area?
-                                            If UserList(tempIndex).AreasInfo.AreaReciveY And UserList(UserIndex).AreasInfo.AreaPerteneceY Then
-                                                If UserList(tempIndex).ConnectionDetails.ConnIDValida Then
-                                                    If UserList(tempIndex).flags.Muerto = 0 Or MapInfo(UserList(tempIndex).pos.Map).Seguro = 1 Then
-                                                        If Not CheckGuildSend(UserList(UserIndex), UserList(tempIndex)) Then
-                                                            If .Counters.timeFx + .Counters.timeChat = 0 Then
-                                                                If Distancia(nPos, UserList(tempIndex).Pos) > DISTANCIA_ENVIO_DATOS Then
-                                                                    'Mandamos los pasos para los pjs q estan lejos para que simule que caminen.
-                                                                    'Mando tambien el char para q lo borre
-                                                                    Call WritePlayWaveStep(tempIndex, .Char.CharIndex, _
-                                                                        MapData(nPos.map, nPos.X, nPos.Y).Graphic(1), MapData(nPos.map, nPos.X, nPos.Y).Graphic(2), _
-                                                                        Distance(nPos.X, nPos.Y, UserList(tempIndex).Pos.X, UserList(tempIndex).Pos.Y), _
-                                                                        Sgn(nPos.X - UserList(tempIndex).Pos.X), .flags.stepToggle)
-                                                                Else
-                                                                    Call WritePosUpdateChar(tempIndex, nPos.X, nPos.Y, .Char.CharIndex)
-                                                                End If
+                                    If tempIndex <> UserIndex And Not EsGM(tempIndex) Then
+                                        If Abs(nPos.X - UserList(tempIndex).pos.X) <= RANGO_VISION_X And Abs(nPos.Y - UserList(tempIndex).pos.Y) <= RANGO_VISION_Y Then
+                                            If UserList(tempIndex).ConnectionDetails.ConnIDValida Then
+                                                If UserList(tempIndex).flags.Muerto = 0 Or MapInfo(UserList(tempIndex).pos.map).Seguro = 1 Then
+                                                    If Not CheckGuildSend(UserList(UserIndex), UserList(tempIndex)) Then
+                                                        If .Counters.timeFx + .Counters.timeChat = 0 Then
+                                                            If Distancia(nPos, UserList(tempIndex).pos) > DISTANCIA_ENVIO_DATOS Then
+                                                                'Mandamos los pasos para los pjs q estan lejos para que simule que caminen.
+                                                                'Mando tambien el char para q lo borre
+                                                                Call WritePlayWaveStep(tempIndex, .Char.charindex, _
+                                                                    MapData(nPos.map, nPos.X, nPos.Y).Graphic(1), MapData(nPos.map, nPos.X, nPos.Y).Graphic(2), _
+                                                                    Distance(nPos.X, nPos.Y, UserList(tempIndex).pos.X, UserList(tempIndex).pos.Y), _
+                                                                    Sgn(nPos.X - UserList(tempIndex).pos.X), .flags.stepToggle)
+                                                            Else
+                                                                Call WritePosUpdateChar(tempIndex, nPos.X, nPos.Y, .Char.charindex)
                                                             End If
                                                         End If
                                                     End If
@@ -1579,7 +1577,7 @@ Function MoveUserChar(ByVal UserIndex As Integer, ByVal nHeading As e_Heading) A
                             For X = nPos.X - DISTANCIA_ENVIO_DATOS To nPos.X + DISTANCIA_ENVIO_DATOS
                                 For y = nPos.y - DISTANCIA_ENVIO_DATOS To nPos.y + DISTANCIA_ENVIO_DATOS
                                     tempIndex = MapData(.Pos.map, X, y).UserIndex
-                                    If tempIndex > 0 And tempIndex <> UserIndex Then
+                                    If tempIndex > 0 And tempIndex <> UserIndex And Not EsGM(tempIndex) Then
                                         If UserList(tempIndex).flags.invisible + UserList(tempIndex).flags.Oculto > 0 And UserList(tempIndex).flags.Navegando = 0 And (.GuildIndex = 0 Or .GuildIndex <> UserList(tempIndex).GuildIndex Or modGuilds.NivelDeClan(.GuildIndex) < 6) Then
                                             Call WritePosUpdateChar(UserIndex, X, y, UserList(tempIndex).Char.charindex)
                                         End If

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -1368,7 +1368,7 @@ Private Sub HandleTalk(ByVal UserIndex As Integer)
                         If Trim(chat) = "" Then
                             .Counters.timeChat = 0
                         Else
-                            .Counters.timeChat = 1 + Round((3000 + 60 * Len(chat)) / 1000)
+                            .Counters.timeChat = 1 + Ceil((3000 + 60 * Len(chat)) / 1000)
                         End If
                         
 150                     Call SendData(SendTarget.ToPCAliveArea, userindex, PrepareMessageChatOverHead(chat, .Char.charindex, .flags.ChatColor, , .Pos.X, .Pos.y))
@@ -1468,7 +1468,7 @@ Private Sub HandleYell(ByVal UserIndex As Integer)
                         If Trim(chat) = "" Then
                             .Counters.timeChat = 0
                         Else
-                            .Counters.timeChat = 1 + Round((3000 + 60 * Len(chat)) / 1000)
+                            .Counters.timeChat = 1 + Ceil((3000 + 60 * Len(chat)) / 1000)
                         End If
 150
                         Call SendData(SendTarget.ToPCAliveArea, userindex, PrepareMessageChatOverHead(chat, .Char.charindex, vbRed, , .Pos.X, .Pos.y))
@@ -3022,7 +3022,7 @@ Private Sub HandleWorkLeftClick(ByVal UserIndex As Integer)
                             FX = ObjData(.Invent.MunicionEqpObjIndex).CreaFX
                         End If
 210                     If FX <> 0 Then
-                            UserList(tU).Counters.timeFx = 2
+                            UserList(tU).Counters.timeFx = 3
 212                         Call SendData(SendTarget.ToPCAliveArea, tU, PrepareMessageCreateFX(UserList(tU).Char.charindex, FX, 0, UserList(tU).Pos.X, UserList(tU).Pos.y))
                         End If
                         If ProjectileType > 0 And (.flags.Oculto = 0 Or Not MapInfo(.pos.Map).KeepInviOnAttack) Then
@@ -3037,7 +3037,7 @@ Private Sub HandleWorkLeftClick(ByVal UserIndex As Integer)
 215                         If ObjData(.Invent.MunicionEqpObjIndex).CreaParticula <> "" Then
 216                             Particula = val(ReadField(1, ObjData(.Invent.MunicionEqpObjIndex).CreaParticula, Asc(":")))
 218                             Tiempo = val(ReadField(2, ObjData(.Invent.MunicionEqpObjIndex).CreaParticula, Asc(":")))
-                                UserList(tU).Counters.timeFx = 2
+                                UserList(tU).Counters.timeFx = 3
 220                             Call SendData(SendTarget.ToPCAliveArea, tU, PrepareMessageParticleFX(UserList(tU).Char.charindex, Particula, Tiempo, False, , UserList(tU).Pos.X, UserList(tU).Pos.y))
                             End If
                         End If
@@ -3439,10 +3439,10 @@ Private Sub HandleWorkLeftClick(ByVal UserIndex As Integer)
 686                     If UserList(tU).flags.Muerto = 0 Then
                             'call marcar
 688                         If UserList(tU).flags.invisible = 1 Or UserList(tU).flags.Oculto = 1 Then
-                                UserList(userindex).Counters.timeFx = 2
+                                UserList(userindex).Counters.timeFx = 3
 690                             Call SendData(SendTarget.ToClanArea, userindex, PrepareMessageParticleFX(UserList(tU).Char.charindex, 210, 50, False, , UserList(userindex).Pos.X, UserList(userindex).Pos.y))
                             Else
-                                UserList(userindex).Counters.timeFx = 2
+                                UserList(userindex).Counters.timeFx = 3
 692                             Call SendData(SendTarget.ToClanArea, userindex, PrepareMessageParticleFX(UserList(tU).Char.charindex, 210, 150, False, , UserList(userindex).Pos.X, UserList(userindex).Pos.y))
                             End If
 694                         Call SendData(SendTarget.ToClanArea, UserIndex, PrepareMessageConsoleMsg("Clan> [" & UserList(UserIndex).Name & "] marco a " & UserList(tU).Name & ".", e_FontTypeNames.FONTTYPE_GUILD))
@@ -5652,7 +5652,7 @@ Private Sub HandleResucitate(ByVal UserIndex As Integer)
             End If
         
 112         Call RevivirUsuario(UserIndex)
-            UserList(userindex).Counters.timeFx = 2
+            UserList(userindex).Counters.timeFx = 3
 114         Call SendData(SendTarget.ToPCAliveArea, userindex, PrepareMessageParticleFX(UserList(userindex).Char.charindex, e_ParticulasIndex.Curar, 100, False, , UserList(userindex).Pos.X, UserList(userindex).Pos.y))
 116         Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessagePlayWave("104", UserList(UserIndex).Pos.X, UserList(UserIndex).Pos.y))
 118         Call WriteConsoleMsg(UserIndex, "¡Has sido resucitado!", e_FontTypeNames.FONTTYPE_INFO)
@@ -6030,7 +6030,8 @@ Private Sub HandleGuildMessage(ByVal UserIndex As Integer)
 116                 If LCase(GuildLeader(.GuildIndex)) = .Name Then
 118                     Call SendData(SendTarget.ToDiosesYclan, .GuildIndex, PrepareMessageGuildChat(.Name & "> " & chat, 10))
                     Else
-                    
+                        .Counters.timeGuildChat = 1 + Ceil((3000 + 60 * Len(chat)) / 1000)
+                        
 120                     Call SendData(SendTarget.ToDiosesYclan, .GuildIndex, PrepareMessageGuildChat(.Name & "> " & chat, .Faccion.Status))
                         Call SendData(SendTarget.ToClanArea, userindex, PrepareMessageChatOverHead("NOCONSOLA*< " & chat & " >", .Char.charindex, RGB(255, 255, 0), , .Pos.X, .Pos.y))
                     End If

--- a/Codigo/ScenarioDeathMatch.cls
+++ b/Codigo/ScenarioDeathMatch.cls
@@ -511,7 +511,7 @@ Private Sub Respawn(ByVal player As Integer)
     SpawnPos.y = RandomNumber(FightAreaTopLeft.y, FightAreaBottomRight.y)
     Call WarpToLegalPos(player, MapNumber, spawnPos.x, spawnPos.y, True, True)
     Call RevivirUsuario(player)
-    UserList(player).Counters.timeFx = 2
+    UserList(player).Counters.timeFx = 3
 114 Call SendData(SendTarget.ToPCAliveArea, player, PrepareMessageParticleFX(UserList(player).Char.charindex, e_ParticulasIndex.Curar, 100, False, , UserList(player).Pos.x, UserList(player).Pos.y))
 116 Call SendData(SendTarget.ToPCAliveArea, player, PrepareMessagePlayWave("104", UserList(player).Pos.x, UserList(player).Pos.y))
 End Sub

--- a/Codigo/ScenarioKillNpc.cls
+++ b/Codigo/ScenarioKillNpc.cls
@@ -418,7 +418,7 @@ Private Sub Respawn(ByVal player As Integer)
     SpawnPos.y = RandomNumber(12, 85)
     Call WarpToLegalPos(player, MapNumber, SpawnPos.x, SpawnPos.y, True, True)
     Call RevivirUsuario(player)
-    UserList(player).Counters.timeFx = 2
+    UserList(player).Counters.timeFx = 3
 114 Call SendData(SendTarget.ToPCAliveArea, player, PrepareMessageParticleFX(UserList(player).Char.charindex, e_ParticulasIndex.Curar, 100, False, , UserList(player).pos.x, UserList(player).pos.y))
 116 Call SendData(SendTarget.ToPCAliveArea, player, PrepareMessagePlayWave("104", UserList(player).pos.x, UserList(player).pos.y))
 End Sub

--- a/Codigo/Scenearios/NavalBoarding.cls
+++ b/Codigo/Scenearios/NavalBoarding.cls
@@ -588,7 +588,7 @@ Private Sub Respawn(ByVal player As Integer)
         Call WarpToLegalPos(player, SpawnPos.Map, SpawnPos.x, SpawnPos.y, True, True)
         Call RevivirUsuario(player)
         .Stats.MinMAN = .Stats.MaxMAN
-        .Counters.timeFx = 2
+        .Counters.timeFx = 3
         .Stats.MinSta = .Stats.MaxSta
         Call WriteUpdateMana(player)
         Call WriteUpdateSta(player)

--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -862,7 +862,7 @@ Public Sub UsuarioAtacaNpc(ByVal UserIndex As Integer, ByVal npcIndex As Integer
 124                         Call WriteLocaleMsg(UserIndex, "136", e_FontTypeNames.FONTTYPE_FIGHT)
 
                         End If
-                        UserList(UserIndex).Counters.timeFx = 2
+                        UserList(UserIndex).Counters.timeFx = 3
 126                     Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessageCreateFX(NpcList(NpcIndex).Char.charindex, 8, 0, UserList(UserIndex).Pos.X, UserList(UserIndex).Pos.y))
                                  
                     Else
@@ -900,7 +900,7 @@ Public Sub UsuarioAtacaNpc(ByVal UserIndex As Integer, ByVal npcIndex As Integer
 146         If Arma > 0 Then
 148             If municionIndex > 0 And ObjData(Arma).Proyectil Then
 150                 If ObjData(municionIndex).CreaFX <> 0 Then
-                        UserList(UserIndex).Counters.timeFx = 2
+                        UserList(UserIndex).Counters.timeFx = 3
 152                     Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessageCreateFX(NpcList(NpcIndex).Char.charindex, ObjData(municionIndex).CreaFX, 0, UserList(UserIndex).Pos.X, UserList(UserIndex).Pos.y))
                     
                     End If
@@ -908,7 +908,7 @@ Public Sub UsuarioAtacaNpc(ByVal UserIndex As Integer, ByVal npcIndex As Integer
 154                 If ObjData(municionIndex).CreaParticula <> "" Then
 156                     Particula = val(ReadField(1, ObjData(municionIndex).CreaParticula, Asc(":")))
 158                     Tiempo = val(ReadField(2, ObjData(municionIndex).CreaParticula, Asc(":")))
-                        UserList(UserIndex).Counters.timeFx = 2
+                        UserList(UserIndex).Counters.timeFx = 3
 160                     Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessageParticleFX(NpcList(NpcIndex).Char.charindex, Particula, Tiempo, False, , UserList(UserIndex).Pos.X, UserList(UserIndex).Pos.y))
                     End If
                 End If
@@ -1119,7 +1119,7 @@ Private Function UsuarioImpacto(ByVal AtacanteIndex As Integer, ByVal VictimaInd
 158             If UserList(VictimaIndex).ChatCombate = 1 Then
 160                 Call Write_BlockedWithShieldUser(VictimaIndex)
                 End If
-                UserList(VictimaIndex).Counters.timeFx = 2
+                UserList(VictimaIndex).Counters.timeFx = 3
 162             Call SendData(SendTarget.ToPCAliveArea, VictimaIndex, PrepareMessageCreateFX(UserList(VictimaIndex).Char.charindex, 88, 0, UserList(VictimaIndex).Pos.X, UserList(VictimaIndex).Pos.y))
 164             Call SubirSkill(VictimaIndex, e_Skill.Defensa)
             Else
@@ -1155,7 +1155,7 @@ Public Sub UsuarioAtacaUsuario(ByVal AtacanteIndex As Integer, ByVal VictimaInde
         Call EffectsOverTime.TartgetWillAtack(UserList(AtacanteIndex).EffectOverTime, VictimaIndex, eUser, e_phisical)
 110     If UsuarioImpacto(AtacanteIndex, VictimaIndex, aType) Then
 112         If UserList(VictimaIndex).flags.Navegando = 0 Or UserList(VictimaIndex).flags.Montado = 0 Then
-                UserList(VictimaIndex).Counters.timeFx = 2
+                UserList(VictimaIndex).Counters.timeFx = 3
 114             Call SendData(SendTarget.ToPCAliveArea, VictimaIndex, PrepareMessageCreateFX(UserList(VictimaIndex).Char.charindex, FXSANGRE, 0, UserList(VictimaIndex).Pos.X, UserList(VictimaIndex).Pos.y))
             End If
 116         Call UserDamageToUser(AtacanteIndex, VictimaIndex, aType)
@@ -1295,7 +1295,7 @@ Private Sub UserDamageToUser(ByVal AtacanteIndex As Integer, ByVal VictimaIndex 
 200                 Color = vbYellow
 
                     ' Efecto en la víctima
-                    UserList(VictimaIndex).Counters.timeFx = 2
+                    UserList(VictimaIndex).Counters.timeFx = 3
 202                 Call SendData(SendTarget.ToPCAliveArea, VictimaIndex, PrepareMessageCreateFX(UserList(VictimaIndex).Char.charindex, 89, 0, UserList(VictimaIndex).Pos.X, UserList(VictimaIndex).Pos.y))
                     
                     ' Efecto en pantalla a ambos
@@ -2018,7 +2018,7 @@ Private Sub UserDañoEspecial(ByVal AtacanteIndex As Integer, ByVal VictimaIndex
 152             UserList(VictimaIndex).Counters.Paralisis = 6
 
 154             Call WriteParalizeOK(VictimaIndex)
-                UserList(VictimaIndex).Counters.timeFx = 2
+                UserList(VictimaIndex).Counters.timeFx = 3
 156             Call SendData(SendTarget.ToPCAliveArea, VictimaIndex, PrepareMessageCreateFX(UserList(VictimaIndex).Char.charindex, 8, 0, UserList(VictimaIndex).Pos.X, UserList(VictimaIndex).Pos.y))
 
 158             Call WriteCombatConsoleMsg(VictimaIndex, "¡" & UserList(AtacanteIndex).name & " te ha paralizado!")
@@ -2034,7 +2034,7 @@ Private Sub UserDañoEspecial(ByVal AtacanteIndex As Integer, ByVal VictimaIndex
 168             UserList(VictimaIndex).Counters.Estupidez = 3 ' segundos?
 
 170             Call WriteDumb(VictimaIndex)
-                UserList(VictimaIndex).Counters.timeFx = 2
+                UserList(VictimaIndex).Counters.timeFx = 3
 172             Call SendData(SendTarget.ToPCAliveArea, VictimaIndex, PrepareMessageParticleFX(UserList(VictimaIndex).Char.charindex, 30, 30, False, , UserList(VictimaIndex).Pos.X, UserList(VictimaIndex).Pos.y))
 
 174             Call WriteCombatConsoleMsg(VictimaIndex, "¡" & UserList(AtacanteIndex).name & " te ha estupidizado!")
@@ -2486,7 +2486,7 @@ Public Sub ThrowProjectileToTarget(ByVal UserIndex As Integer, ByVal TargetIndex
                 FX = ObjData(.MunicionEqpObjIndex).CreaFX
             End If
             If FX <> 0 Then
-                UserList(TargetIndex).Counters.timeFx = 2
+                UserList(TargetIndex).Counters.timeFx = 3
                 Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessageCreateFX(UserList(TargetIndex).Char.charindex, FX, 0, UserList(TargetIndex).pos.x, UserList(TargetIndex).pos.y))
             End If
             If ProjectileType > 0 And UserList(UserIndex).flags.Oculto = 0 Then
@@ -2501,7 +2501,7 @@ Public Sub ThrowProjectileToTarget(ByVal UserIndex As Integer, ByVal TargetIndex
                 If ObjData(.MunicionEqpObjIndex).CreaParticula <> "" Then
                     Particula = val(ReadField(1, ObjData(.MunicionEqpObjIndex).CreaParticula, Asc(":")))
                     Tiempo = val(ReadField(2, ObjData(.MunicionEqpObjIndex).CreaParticula, Asc(":")))
-                    UserList(TargetIndex).Counters.timeFx = 2
+                    UserList(TargetIndex).Counters.timeFx = 3
                     Call SendData(SendTarget.ToPCAliveArea, TargetIndex, PrepareMessageParticleFX(UserList(TargetIndex).Char.charindex, Particula, Tiempo, False, , UserList(TargetIndex).pos.x, UserList(TargetIndex).pos.y))
                 End If
             End If

--- a/Codigo/TCP.bas
+++ b/Codigo/TCP.bas
@@ -1169,6 +1169,7 @@ Sub ResetContadores(ByVal UserIndex As Integer)
             .controlHechizos.HechizosTotales = 0
             .timeChat = 0
             .timeFx = 0
+            .timeGuildChat = 0
         End With
 
         

--- a/Codigo/Trabajo.bas
+++ b/Codigo/Trabajo.bas
@@ -461,7 +461,7 @@ Public Sub DoOcultarse(ByVal UserIndex As Integer)
                         Call RefreshCharStatus(UserIndex)
                     End If
                 Else
-                    UserList(UserIndex).Counters.timeFx = 2
+                    UserList(UserIndex).Counters.timeFx = 3
 152                 Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessageSetInvisible(.Char.charindex, True, UserList(UserIndex).Pos.X, UserList(UserIndex).Pos.Y))
                     'Call WriteConsoleMsg(UserIndex, "¡Te has escondido entre las sombras!", e_FontTypeNames.FONTTYPE_INFO)
 154                 Call WriteLocaleMsg(UserIndex, "55", e_FontTypeNames.FONTTYPE_INFO)

--- a/Codigo/modHechizos.bas
+++ b/Codigo/modHechizos.bas
@@ -1331,7 +1331,7 @@ Function HandlePhysicalSkill(ByVal SourceIndex As Integer, ByVal SourceType As e
             If RefDoDamageToTarget(SourceRef, TargetRef, Damage, e_phisical, ObjectIndex) = eStillAlive Then
                 IsAlive = True
                 If TargetRef.RefType = eUser Then
-                    UserList(TargetRef.ArrayIndex).Counters.timeFx = 2
+                    UserList(TargetRef.ArrayIndex).Counters.timeFx = 3
                     Call SendData(SendTarget.ToPCAliveArea, TargetRef.ArrayIndex, PrepareMessageCreateFX(UserList(TargetRef.ArrayIndex).Char.charindex, FXSANGRE, 0, UserList(TargetRef.ArrayIndex).pos.x, UserList(TargetRef.ArrayIndex).pos.y))
                     Call SendData(SendTarget.ToPCAliveArea, TargetRef.ArrayIndex, PrepareMessagePlayWave(SND_IMPACTO, UserList(TargetRef.ArrayIndex).pos.x, UserList(TargetRef.ArrayIndex).pos.y))
                 Else
@@ -2811,20 +2811,20 @@ Private Sub InfoHechizoDeNpcSobreUser(ByVal NpcIndex As Integer, ByVal TargetUse
 100   With UserList(TargetUser)
 102     If Hechizos(Spell).FXgrh > 0 Then '¿Envio FX?
 104       If Hechizos(Spell).ParticleViaje > 0 Then
-            .Counters.timeFx = 2
+            .Counters.timeFx = 3
 106         Call SendData(SendTarget.ToPCArea, TargetUser, PrepareMessageParticleFXWithDestino(NpcList(NpcIndex).Char.charindex, .Char.charindex, Hechizos(Spell).ParticleViaje, Hechizos(Spell).FXgrh, Hechizos(Spell).TimeParticula, Hechizos(Spell).wav, 1, UserList(TargetUser).Pos.X, UserList(TargetUser).Pos.Y))
           Else
-            .Counters.timeFx = 2
+            .Counters.timeFx = 3
 108         Call SendData(SendTarget.ToPCArea, TargetUser, PrepareMessageCreateFX(.Char.charindex, Hechizos(Spell).FXgrh, Hechizos(Spell).loops, UserList(TargetUser).Pos.X, UserList(TargetUser).Pos.Y))
           End If
         End If
 
 110     If Hechizos(Spell).Particle > 0 Then '¿Envio Particula?
 112       If Hechizos(Spell).ParticleViaje > 0 Then
-            .Counters.timeFx = 2
+            .Counters.timeFx = 3
 114         Call SendData(SendTarget.ToPCArea, TargetUser, PrepareMessageParticleFXWithDestino(NpcList(NpcIndex).Char.charindex, .Char.charindex, Hechizos(Spell).ParticleViaje, Hechizos(Spell).Particle, Hechizos(Spell).TimeParticula, Hechizos(Spell).wav, 0, UserList(TargetUser).Pos.X, UserList(TargetUser).Pos.Y))
           Else
-            .Counters.timeFx = 2
+            .Counters.timeFx = 3
 116         Call SendData(SendTarget.ToPCArea, TargetUser, PrepareMessageParticleFX(.Char.charindex, Hechizos(Spell).Particle, Hechizos(Spell).TimeParticula, False, , UserList(TargetUser).Pos.X, UserList(TargetUser).Pos.Y))
           End If
         End If
@@ -2863,10 +2863,10 @@ Private Sub InfoHechizo(ByVal UserIndex As Integer)
 106     If IsValidUserRef(UserList(UserIndex).flags.TargetUser) Then '¿El Hechizo fue tirado sobre un usuario?
 108         If Hechizos(h).FXgrh > 0 Then '¿Envio FX?
 110             If Hechizos(h).ParticleViaje > 0 Then
-                    UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).Counters.timeFx = 2
+                    UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).Counters.timeFx = 3
 112                 Call SendData(SendTarget.ToPCAliveArea, UserList(UserIndex).flags.targetUser.ArrayIndex, PrepareMessageParticleFXWithDestino(UserList(UserIndex).Char.charindex, UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).Char.charindex, Hechizos(h).ParticleViaje, Hechizos(h).FXgrh, Hechizos(h).TimeParticula, Hechizos(h).wav, 1, UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).pos.x, UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).pos.y))
                 Else
-                    UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).Counters.timeFx = 2
+                    UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).Counters.timeFx = 3
 114                 Call SendData(SendTarget.ToPCAliveArea, UserList(UserIndex).flags.targetUser.ArrayIndex, PrepareMessageCreateFX(UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).Char.charindex, Hechizos(h).FXgrh, Hechizos(h).loops, UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).pos.x, UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).pos.y))
                 End If
 
@@ -2874,10 +2874,10 @@ Private Sub InfoHechizo(ByVal UserIndex As Integer)
 
 116         If Hechizos(h).Particle > 0 Then '¿Envio Particula?
 118             If Hechizos(h).ParticleViaje > 0 Then
-                    UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).Counters.timeFx = 2
+                    UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).Counters.timeFx = 3
 120                 Call SendData(SendTarget.ToPCAliveArea, UserList(UserIndex).flags.targetUser.ArrayIndex, PrepareMessageParticleFXWithDestino(UserList(UserIndex).Char.charindex, UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).Char.charindex, Hechizos(h).ParticleViaje, Hechizos(h).Particle, Hechizos(h).TimeParticula, Hechizos(h).wav, 0, UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).pos.x, UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).pos.y))
                 Else
-                    UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).Counters.timeFx = 2
+                    UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).Counters.timeFx = 3
 122                 Call SendData(SendTarget.ToPCAliveArea, UserList(UserIndex).flags.targetUser.ArrayIndex, PrepareMessageParticleFX(UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).Char.charindex, Hechizos(h).Particle, Hechizos(h).TimeParticula, False, , UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).pos.x, UserList(UserList(UserIndex).flags.targetUser.ArrayIndex).pos.y))
                 End If
 

--- a/Codigo/modSendData.bas
+++ b/Codigo/modSendData.bas
@@ -731,13 +731,24 @@ Private Function CanSendToUser(ByRef SourceUser As t_User, ByRef TargetUser As t
         Call modNetwork.Send(TargetUser.flags.GMMeSigue.ArrayIndex, Buffer)
     End If
     If Not EsGM(TargetIndex) Then
-        If SourceUser.flags.invisible + SourceUser.flags.Oculto > 0 And ValidateInvi And Not (TargetUser.GuildIndex > 0 And TargetUser.GuildIndex = SourceUser.GuildIndex And modGuilds.NivelDeClan(TargetUser.GuildIndex) >= 6) And SourceUser.flags.Navegando = 0 Then
+        If SourceUser.flags.invisible + SourceUser.flags.Oculto > 0 And ValidateInvi And Not CheckGuildSend(SourceUser, TargetUser) And SourceUser.flags.Navegando = 0 Then
             If Distancia(SourceUser.pos, TargetUser.pos) > DISTANCIA_ENVIO_DATOS And SourceUser.Counters.timeFx + SourceUser.Counters.timeChat = 0 Then
                 Exit Function
             End If
         End If
     End If
     CanSendToUser = True
+End Function
+
+Public Function CheckGuildSend(ByRef SourceUser As t_User, ByRef TargetUser As t_User) As Boolean
+    CheckGuildSend = False
+    If SourceUser.GuildIndex = 0 Then Exit Function
+    If SourceUser.GuildIndex <> TargetUser.GuildIndex Then Exit Function
+    If modGuilds.NivelDeClan(TargetUser.GuildIndex) < 6 Then
+        CheckGuildSend = SourceUser.Counters.timeGuildChat > 0
+        Exit Function
+    End If
+    CheckGuildSend = True
 End Function
 
 Private Sub SendToUserAliveAreaButindex(ByVal UserIndex As Integer, ByRef Buffer As Network.Writer, Optional ByVal ValidateInvi As Boolean = False)


### PR DESCRIPTION
Para evitar carteles y fxs saltarines:
- Alargo el tiempo de animacion en invisible de dialogos y fxs
- Agrego timer para dialogos de clan

Fix en merge anterior los gms dejaron de ver los users invisibles
Creo que también fixee que los usuarios puedan patear gms? Esto hay que probarlo