### PR TITLE
Fixed type parameter in Server.Kick and added text description for all of them

### DIFF
--- a/Codigo/modNetwork.bas
+++ b/Codigo/modNetwork.bas
@@ -118,7 +118,7 @@ On Error GoTo Kick_ErrHandler:
     End If
         
     Call Server.Flush(Connection)
-    Call Server.Kick(Connection, True)
+    Call Server.Kick(Connection, "Kick Server.kick")
     Exit Sub
     
 Kick_ErrHandler:
@@ -235,7 +235,7 @@ On Error GoTo OnServerSend_Err:
     Exit Sub
     
 OnServerSend_Err:
-    Call Kick(Connection)
+    Call Kick(Connection, "OnServerClose kick")
     Call TraceError(Err.Number, Err.Description, "modNetwork.OnServerSend", Erl)
 End Sub
 
@@ -250,7 +250,7 @@ On Error GoTo OnServerRecv_Err:
     Exit Sub
     
 OnServerRecv_Err:
-    Call Kick(Connection)
+    Call Kick(Connection, "OnServerRecv kick")
     Call TraceError(Err.Number, Err.Description, "modNetwork.OnServerRecv", Erl)
 End Sub
 
@@ -259,7 +259,7 @@ On Error GoTo ForcedClose_Err:
 100     UserList(UserIndex).ConnectionDetails.ConnIDValida = False
 102     UserList(UserIndex).ConnectionDetails.ConnID = 0
 104     Call Server.Flush(Connection)
-106     Call Server.Kick(Connection, True)
+106     Call Server.Kick(Connection, "ForcedClose kick")
 108     Call ClearUserRef(Mapping(Connection).UserRef)
 110     Call IncreaseVersionId(userIndex)
         Exit Sub
@@ -270,7 +270,7 @@ End Sub
 Public Sub KickConnection(Connection As Long)
 On Error GoTo ForcedClose_Err:
 104     Call Server.Flush(Connection)
-106     Call Server.Kick(Connection, True)
+106     Call Server.Kick(Connection, "KickConnection kick")
 108     Call ClearConnection(Connection)
 110     If PendingConnections.Exists(Connection) Then
 112         Call PendingConnections.Remove(Connection)


### PR DESCRIPTION
We have reports that the game was broken with these kind of error for sending a boolean instead of string.

Fixes

![image](https://github.com/ao-org/argentum-online-server/assets/5874806/2d5c6060-1a6d-45d9-9c07-327c63d8036a)


![image](https://github.com/ao-org/argentum-online-server/assets/5874806/ac8a43b9-0bbd-4e1d-9e50-273953275094)
