### PR TITLE
Nuevos viajes en barco

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -1295,10 +1295,9 @@ Public Enum e_TrapEffect
 End Enum
 
 Public Enum e_TripState
-    eNixToForgat = 1
     eForgatToNix
+    eNixToArghal
     eArghalToForgat
-    eForgatToArghal
 End Enum
 
 Public Type t_Transport
@@ -2983,7 +2982,9 @@ Public Renacimiento                       As t_WorldPos
 Public NixDock                            As t_Transport
 Public ForgatDock                         As t_Transport
 Public ArghalDock                         As t_Transport
-Public BarcoNavegando                     As t_Transport
+Public BarcoNavegandoForgatNix            As t_Transport
+Public BarcoNavegandoNixArghal            As t_Transport
+Public BarcoNavegandoArghalForgat         As t_Transport
 
 Public TotalMapasCiudades()               As String
 Public Ayuda                              As New cCola

--- a/Codigo/FileIO.bas
+++ b/Codigo/FileIO.bas
@@ -2563,17 +2563,43 @@ Sub CargarCiudades()
             .y = val(Lector.GetValue("Renacimiento", "Y"))
         End With
         
-        With BarcoNavegando
-            .Map = val(Lector.GetValue("BarcoNavegando", "Mapa"))
-            .StartX = val(Lector.GetValue("BarcoNavegando", "StartX"))
-            .StartY = val(Lector.GetValue("BarcoNavegando", "StartY"))
-            .EndX = val(Lector.GetValue("BarcoNavegando", "EndX"))
-            .EndY = val(Lector.GetValue("BarcoNavegando", "EndY"))
-            .DestX = val(Lector.GetValue("BarcoNavegando", "DestX"))
-            .DestY = val(Lector.GetValue("BarcoNavegando", "DestY"))
-            .DockX = val(Lector.GetValue("BarcoNavegando", "DockX"))
-            .DockY = val(Lector.GetValue("BarcoNavegando", "DockY"))
-            .RequiredPassID = val(Lector.GetValue("BarcoNavegando", "RequiredPassID"))
+        With BarcoNavegandoForgatNix
+            .Map = val(Lector.GetValue("BarcoNavegandoForgatNix", "Mapa"))
+            .startX = val(Lector.GetValue("BarcoNavegandoForgatNix", "StartX"))
+            .startY = val(Lector.GetValue("BarcoNavegandoForgatNix", "StartY"))
+            .EndX = val(Lector.GetValue("BarcoNavegandoForgatNix", "EndX"))
+            .EndY = val(Lector.GetValue("BarcoNavegandoForgatNix", "EndY"))
+            .DestX = val(Lector.GetValue("BarcoNavegandoForgatNix", "DestX"))
+            .DestY = val(Lector.GetValue("BarcoNavegandoForgatNix", "DestY"))
+            .DockX = val(Lector.GetValue("BarcoNavegandoForgatNix", "DockX"))
+            .DockY = val(Lector.GetValue("BarcoNavegandoForgatNix", "DockY"))
+            .RequiredPassID = val(Lector.GetValue("BarcoNavegandoForgatNix", "RequiredPassID"))
+        End With
+        
+        With BarcoNavegandoNixArghal
+            .Map = val(Lector.GetValue("BarcoNavegandoNixArghal", "Mapa"))
+            .startX = val(Lector.GetValue("BarcoNavegandoNixArghal", "StartX"))
+            .startY = val(Lector.GetValue("BarcoNavegandoNixArghal", "StartY"))
+            .EndX = val(Lector.GetValue("BarcoNavegandoNixArghal", "EndX"))
+            .EndY = val(Lector.GetValue("BarcoNavegandoNixArghal", "EndY"))
+            .DestX = val(Lector.GetValue("BarcoNavegandoNixArghal", "DestX"))
+            .DestY = val(Lector.GetValue("BarcoNavegandoNixArghal", "DestY"))
+            .DockX = val(Lector.GetValue("BarcoNavegandoNixArghal", "DockX"))
+            .DockY = val(Lector.GetValue("BarcoNavegandoNixArghal", "DockY"))
+            .RequiredPassID = val(Lector.GetValue("BarcoNavegandoNixArghal", "RequiredPassID"))
+        End With
+        
+        With BarcoNavegandoArghalForgat
+            .Map = val(Lector.GetValue("BarcoNavegandoArghalForgat", "Mapa"))
+            .startX = val(Lector.GetValue("BarcoNavegandoArghalForgat", "StartX"))
+            .startY = val(Lector.GetValue("BarcoNavegandoArghalForgat", "StartY"))
+            .EndX = val(Lector.GetValue("BarcoNavegandoArghalForgat", "EndX"))
+            .EndY = val(Lector.GetValue("BarcoNavegandoArghalForgat", "EndY"))
+            .DestX = val(Lector.GetValue("BarcoNavegandoArghalForgat", "DestX"))
+            .DestY = val(Lector.GetValue("BarcoNavegandoArghalForgat", "DestY"))
+            .DockX = val(Lector.GetValue("BarcoNavegandoArghalForgat", "DockX"))
+            .DockY = val(Lector.GetValue("BarcoNavegandoArghalForgat", "DockY"))
+            .RequiredPassID = val(Lector.GetValue("BarcoNavegandoArghalForgat", "RequiredPassID"))
         End With
         
         With ForgatDock
@@ -2586,7 +2612,7 @@ Sub CargarCiudades()
             .DestY = val(Lector.GetValue("ForgatDock", "DestY"))
             .DockX = val(Lector.GetValue("ForgatDock", "DockX"))
             .DockY = val(Lector.GetValue("ForgatDock", "DockY"))
-            .RequiredPassID = val(Lector.GetValue("BarcoNavegando", "RequiredPassID"))
+            .RequiredPassID = val(Lector.GetValue("BarcoNavegandoForgatNix", "RequiredPassID"))
         End With
         
         With NixDock
@@ -2599,7 +2625,7 @@ Sub CargarCiudades()
             .DestY = val(Lector.GetValue("NixDock", "DestY"))
             .DockX = val(Lector.GetValue("NixDock", "DockX"))
             .DockY = val(Lector.GetValue("NixDock", "DockY"))
-            .RequiredPassID = val(Lector.GetValue("BarcoNavegando", "RequiredPassID"))
+            .RequiredPassID = val(Lector.GetValue("BarcoNavegandoNixArghal", "RequiredPassID"))
         End With
         
         With ArghalDock
@@ -2612,7 +2638,7 @@ Sub CargarCiudades()
             .DestY = val(Lector.GetValue("ArghalDock", "DestY"))
             .DockX = val(Lector.GetValue("ArghalDock", "DockX"))
             .DockY = val(Lector.GetValue("ArghalDock", "DockY"))
-            .RequiredPassID = val(Lector.GetValue("BarcoNavegando", "RequiredPassID"))
+            .RequiredPassID = val(Lector.GetValue("BarcoNavegandoArghalForgat", "RequiredPassID"))
         End With
         
         

--- a/Codigo/General.bas
+++ b/Codigo/General.bas
@@ -705,7 +705,9 @@ Sub Main()
             .tControlHechizos.Interval = 60000
             If IsFeatureEnabled("ShipTravelEnabled") Then
                 .TimerBarco.Enabled = True
-                MapInfo(BarcoNavegando.map).ForceUpdate = True
+                MapInfo(BarcoNavegandoForgatNix.Map).ForceUpdate = True
+                MapInfo(BarcoNavegandoNixArghal.Map).ForceUpdate = True
+                MapInfo(BarcoNavegandoArghalForgat.Map).ForceUpdate = True
             End If
             
             

--- a/Codigo/LocaleDef.bas
+++ b/Codigo/LocaleDef.bas
@@ -115,7 +115,10 @@ Public Const MsgNavalBattleRewardBroadcast = 486
 Public Const MsgBoardcastInscriptionPrice = 487
 Public Const MsgMatchComplete = 488
 Public Const MsgInvalidPassword = 489
-Public Const MsgThanksForTravelArghal = 490
+Public Const MsgPassArghal = 490
+Public Const MsgThanksForTravelArghal = 491
+
+
 
 Public Function GetRequiredWeaponLocaleId(ByVal WeaponType As e_WeaponType) As Integer
     Select Case WeaponType


### PR DESCRIPTION
Reemplazo el viaje en barco de nix/arghal a forgat y viceversa que hay actualmente por:
- 3 eventos que manejan 3 barcos independientes
- un barco va de forgat a nix
- otro va de nix a arghal
- otro va de arghal a forgat
Esto es beneficioso por varios motivos:
- Acorta mucho las distancias, los usuarios podrán tomarse el barco para viajar al precio del boleto rodeando todo el mundo
- Los 3 barcos son independientes, usan mapas distintos por lo que no se deben esperar entre si
- Simplifiqué la lógica que tenían los viajes, es más simple de entender y en todo caso quedan herramientas para complejizar a gusto