### PR TITLE
Envío a Isla de la Fortuna sin importar el mapa

### DIFF
--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -250,17 +250,12 @@ Sub QuitarNewbieObj(ByVal UserIndex As Integer)
         End If
     
         'Si el usuario dejó de ser Newbie, y estaba en el Newbie Dungeon
-
-112     If MapInfo(UserList(UserIndex).pos.map).Newbie Then
-                   
-            'Mandamos a la isla de renacimiento
-            Call WarpUserChar(UserIndex, Renacimiento.map, Renacimiento.X, Renacimiento.y, True)
-            Call WriteConsoleMsg(UserIndex, "Has dejado de ser Newbie, Te orientaremos que hacer ahora.", e_FontTypeNames.FONTTYPE_INFO)
-            
-    
-        End If
-
         
+        'Mandamos a la Isla de la Fortuna
+        
+        Call WarpUserChar(UserIndex, Renacimiento.Map, Renacimiento.x, Renacimiento.y, True)
+        Call WriteConsoleMsg(UserIndex, "Has dejado de ser Newbie, Te orientaremos que hacer ahora.", e_FontTypeNames.FONTTYPE_INFO)
+
         Exit Sub
 
 QuitarNewbieObj_Err:


### PR DESCRIPTION
Cuando un personaje pasa a nivel 13 y deja de ser Newbie es teletransportado a la Isla de la Fortuna donde obtiene algo de equipamiento básico. Este cambio es para que cualquier personaje que pase a 13 sin importar el mapa pueda ir a la isla. Antes solo te enviaba a la isla si pasabas en Dungeon Newbie.