### PR TITLE
Actualizo código de pesca

### DIFF
--- a/Codigo/Admin.bas
+++ b/Codigo/Admin.bas
@@ -158,6 +158,7 @@ Public AssistHelpValidTime          As Long 'valid time for helpful spell to cou
 Public HideAfterHitTime             As Long 'required time to hide again after a hit remove us from this state
 Public FactionReKillTime            As Long 'required time between killing the same user to get factions points
 Public AirHitReductParalisisTime    As Integer 'you can hit to the air to reduce inmo/paralisis time
+Public PorcentajePescaSegura        As Integer 'Porcentaje de reducción a la pesca en zona segura
 
 Public Puerto                       As Long
 Public ListenIp                     As String

--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2960,6 +2960,8 @@ Public ModClase(1 To NUMCLASES)           As t_ModClase
 Public ModRaza(1 To NUMRAZAS)             As t_ModRaza
 Public Crafteos                           As New Dictionary
 Public GlobalDropTable()                  As t_GlobalDrop
+Public PoderCanas()                       As Integer
+
 '*********************************************************
 
 Public Nix                                As t_WorldPos

--- a/Codigo/FileIO.bas
+++ b/Codigo/FileIO.bas
@@ -1089,6 +1089,8 @@ Sub LoadBalance()
         HideAfterHitTime = val(BalanceIni.GetValue("EXTRA", "HideAfterHitTime"))
         FactionReKillTime = val(BalanceIni.GetValue("EXTRA", "FactionReKillTime"))
         AirHitReductParalisisTime = val(BalanceIni.GetValue("EXTRA", "AirHitReductParalisisTime"))
+        PorcentajePescaSegura = val(BalanceIni.GetValue("EXTRA", "PorcentajePescaSegura"))
+        
         'stun
         PlayerStunTime = val(BalanceIni.GetValue("STUN", "PlayerStunTime"))
         NpcStunTime = val(BalanceIni.GetValue("STUN", "NpcStunTime"))
@@ -3249,8 +3251,8 @@ Public Sub LoadPesca()
 102         ReDim Peces(0) As t_Obj
             ReDim PecesEspeciales(0) As t_Obj
 104         ReDim PesoPeces(0) As Long
+            ReDim PoderCanas(0) As Integer
             Exit Sub
-
         End If
 
         Dim IniFile As clsIniManager
@@ -3265,6 +3267,11 @@ Public Sub LoadPesca()
 112     MaxLvlCania = val(IniFile.GetValue("PECES", "Maxlvlcaña"))
         CountEspecial = 1
 114     ReDim PesoPeces(0 To MaxLvlCania) As Long
+
+        ReDim PoderCanas(0 To MaxLvlCania) As Integer
+        For i = 1 To MaxLvlCania
+            PoderCanas(i) = val(IniFile.GetValue("POWERCANAS", "Power" & i))
+        Next i
     
 116     If Count > 0 Then
 118         ReDim Peces(1 To Count) As t_Obj


### PR DESCRIPTION
- Ahora se puede pescar en zona insegura con caña, la red sigue sirviendo solo en las áreas de pesca.
- Ahora se puede poner el porcentaje de reducción de pesca en zona segura respecto a insegura desde el dateo de balance.dat. Aquí se puede poner 10% y queda ínfima.
- Ahora se puede definir la bonificación que dan las cañas en el dateo de pesca.dat, antes estaba hardcodeado. Estos valores dependen del Power que tengan en el obj.dat.
- Ahora la pesca en zona segura NO sube skills en pesca.
- Saqué la bonificación de clase para trabajadores ya que solo pescan trabajadores
- Saqué la restricción hardcodeada de puntos de pesca para usar la red, ya que se restringe por nivel en el obj.dat
- Documenté un poco el código