### PR TITLE
Creado Archivo BAT para registrar AuroraNetwork

### DIFF
--- a/RegistrarAurora.bat
+++ b/RegistrarAurora.bat
@@ -1,0 +1,14 @@
+@echo off
+:: Establece la ruta de trabajo a la ubicación del archivo .bat
+cd /d %~dp0
+
+:: Comprueba si se está ejecutando como administrador
+net session >nul 2>&1
+if %errorLevel% NEQ 0 (
+    echo Requiere permisos de administrador. Ejecutando de nuevo con privilegios elevados...
+    powershell start-process "%~0" -verb runas
+    exit
+)
+
+:: Ejecuta el comando regsvr32 para registrar la DLL
+regsvr32 Aurora.Network.dll


### PR DESCRIPTION
Se crea archivo BAT para auto-registrar la DLL AuroraNetwork en la carpeta donde esté instalado el server, si no se ejecuta como Administrador el BAT alerta al usuario y lo corre como Administrador, evitando asi cualquier tipo de incoveniente con la registración del mismo.