### PR TITLE
Requisitos para Fundar un Clan

### DIFF
--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -8496,13 +8496,13 @@ Private Sub HandleQuieroFundarClan(ByVal UserIndex As Integer)
                 Exit Sub
             End If
 
-108         If UserList(UserIndex).Stats.ELV < 25 Or UserList(UserIndex).Stats.UserSkills(e_Skill.liderazgo) < 35 Then
-110             Call WriteConsoleMsg(UserIndex, "Para fundar un clan debes ser nivel 25, tener 35 en liderazgo y tener en tu inventario las 4 gemas: Gema Polar(1), Gema Roja(1), Gema Azul (1), Gema Verde (1).", e_FontTypeNames.FONTTYPE_INFOIAO)
+108         If UserList(UserIndex).Stats.ELV < 23 Or UserList(UserIndex).Stats.UserSkills(e_Skill.liderazgo) < 50 Then
+110             Call WriteConsoleMsg(UserIndex, "Para fundar un clan debes ser Nivel 23, tener 50 en liderazgo y tener en tu inventario las 4 Gemas de Fundación: Gema Verde, Gema Roja, Gema Azul y Gema Polar.", e_FontTypeNames.FONTTYPE_INFOIAO)
                 Exit Sub
             End If
 
 112         If Not TieneObjetos(407, 1, UserIndex) Or Not TieneObjetos(408, 1, UserIndex) Or Not TieneObjetos(409, 1, UserIndex) Or Not TieneObjetos(412, 1, UserIndex) Then
-114             Call WriteConsoleMsg(UserIndex, "Para fundar un clan debes tener en tu inventario las 4 gemas: Gema Polar(1), Gema Roja(1), Gema Azul (1), Gema Verde (1).", e_FontTypeNames.FONTTYPE_INFOIAO)
+114             Call WriteConsoleMsg(UserIndex, "Para fundar un clan debes tener en tu inventario las 4 Gemas de Fundación: Gema Verde, Gema Roja, Gema Azul y Gema Polar.", e_FontTypeNames.FONTTYPE_INFOIAO)
                 Exit Sub
             End If
 

--- a/Codigo/modGuilds.bas
+++ b/Codigo/modGuilds.bas
@@ -464,28 +464,28 @@ Public Function PuedeFundarUnClan(ByVal UserIndex As Integer, ByVal Alineacion A
             Exit Function
         End If
     
-106     If UserList(UserIndex).Stats.ELV < 25 Or UserList(UserIndex).Stats.UserSkills(e_Skill.liderazgo) < 35 Then
-108         refError = "Para fundar un clan debes ser nivel 25, tener 35 puntos en liderazgo y tener en tu inventario las Gemas Azul, Polar, Roja y Verde (Fundación)."
+106     If UserList(UserIndex).Stats.ELV < 23 Or UserList(UserIndex).Stats.UserSkills(e_Skill.liderazgo) < 50 Then
+108         refError = "Para fundar un clan debes ser Nivel 23, tener 50 puntos en liderazgo y tener en tu inventario las Gemas de Fundación Verde, Roja, Azul y Polar."
             Exit Function
         End If
     
 110     If Not TieneObjetos(407, 1, UserIndex) Then
-112         refError = "Para fundar un clan debes ser nivel 25, tener 35 puntos en liderazgo y tener en tu inventario las Gemas Azul, Polar, Roja y Verde (Fundación)."
+112         refError = "Para fundar un clan debes ser nivel 23, tener 50 puntos en liderazgo y tener en tu inventario las Gemas de Fundación Verde, Roja, Azul y Polar."
             Exit Function
         End If
     
 114     If Not TieneObjetos(408, 1, UserIndex) Then
-116         refError = "Para fundar un clan debes ser nivel 25, tener 35 puntos en liderazgo y tener en tu inventario las Gemas Azul, Polar, Roja y Verde (Fundación)."
+116         refError = "Para fundar un clan debes ser nivel 23, tener 50 puntos en liderazgo y tener en tu inventario las Gemas de Fundación Verde, Roja, Azul y Polar."
             Exit Function
         End If
         
 121             If Not TieneObjetos(409, 1, UserIndex) Then
-122         refError = "Para fundar un clan debes ser nivel 25, tener 35 puntos en liderazgo y tener en tu inventario las Gemas Azul, Polar, Roja y Verde (Fundación)."
+122         refError = "Para fundar un clan debes ser nivel 23, tener 50 puntos en liderazgo y tener en tu inventario las Gemas de Fundación Verde, Roja, Azul y Polar."
             Exit Function
         End If
     
 123     If Not TieneObjetos(412, 1, UserIndex) Then
-124         refError = "Para fundar un clan debes ser nivel 25, tener 35 puntos en liderazgo y tener en tu inventario las Gemas Azul, Polar, Roja y Verde (Fundación)."
+124         refError = "Para fundar un clan debes ser nivel 23, tener 50 puntos en liderazgo y tener en tu inventario las Gemas de Fundación Verde, Roja, Azul y Polar."
             Exit Function
         End If
         


### PR DESCRIPTION
Actualizamos los requisitos necesarios para fundar un clan dentro de Argentum Online:

- Reducción de Nivel: ahora se puede fundar a partir de Nivel 23 (solicitaba ser Nivel 25 o más)
- Aumento de Skills: ahora es necesario tener 50 puntos en Liderazgo para fundar un clan (solicitaba 35 puntos en Liderazgo)