### PR TITLE
Premium slots temporary disabled, all characters have the same qty slots

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -806,13 +806,13 @@ Public Const MAX_INVENTORY_OBJS      As Integer = 10000
 
 ''
 ' Cantidad de "slots" en el inventario con todos los slots desbloqueados
-Public Const MAX_INVENTORY_SLOTS     As Byte = 42
+Public Const MAX_INVENTORY_SLOTS     As Byte = 24
 
 ' Cantidad de "slots" en el inventario básico
 Public Const MAX_USERINVENTORY_SLOTS As Byte = 24
 
 ' Cantidad de "slots" en el inventario heroe
-Public Const MAX_USERINVENTORY_HERO_SLOTS As Byte = 31
+Public Const MAX_USERINVENTORY_HERO_SLOTS As Byte = 24
 
 ' Cantidad de "slots" en el inventario por fila
 Public Const SLOTS_PER_ROW_INVENTORY As Byte = 6


### PR DESCRIPTION
This pull request includes changes to the inventory slot constants in the `Codigo/Declares.bas` file. The changes adjust the number of slots available in different types of inventories to ensure consistency and balance.

Changes to inventory slot constants:

* [`Codigo/Declares.bas`](diffhunk://#diff-9682fb78ca936b593db35585cec8ff7c38ac045a2cc5f5f6b140d03aa0488813L809-R815): Reduced `MAX_INVENTORY_SLOTS` from 42 to 24.
* [`Codigo/Declares.bas`](diffhunk://#diff-9682fb78ca936b593db35585cec8ff7c38ac045a2cc5f5f6b140d03aa0488813L809-R815): Reduced `MAX_USERINVENTORY_HERO_SLOTS` from 31 to 24.