### PR TITLE
WIP DO NOT MERGE: Replacing GetTickCount with GetTickCount64

### DIFF
--- a/Codigo/Admin.bas
+++ b/Codigo/Admin.bas
@@ -60,9 +60,8 @@ Public dias                         As Long
 
 Public MinsRunning                  As Long
 
-Public ReiniciarServer              As Long
 
-Public tInicioServer                As Long
+Public tInicioServer                As Double
 
 'INTERVALOS
 Public SanaIntervaloSinDescansar    As Integer
@@ -73,13 +72,9 @@ Public IntervaloPerderStamina       As Integer
 Public IntervaloSed                 As Integer
 Public IntervaloHambre              As Integer
 Public IntervaloVeneno              As Integer
-
-'Ladder
 Public IntervaloIncineracion        As Integer
 Public IntervaloInmovilizado        As Integer
 Public IntervaloMaldicion           As Integer
-'Ladder
-
 Public IntervaloParalizado          As Integer
 Public IntervaloInvisible           As Integer
 Public IntervaloFrio                As Integer
@@ -87,48 +82,30 @@ Public IntervaloWavFx               As Integer
 Public IntervaloNPCPuedeAtacar      As Integer
 Public IntervaloNPCAI               As Integer
 Public IntervaloInvocacion          As Integer
-Public IntervaloOculto              As Integer '[Nacho]
+Public IntervaloOculto              As Integer
 Public IntervaloUserPuedeAtacar     As Long
 Public IntervaloMagiaGolpe          As Long
 Public IntervaloGolpeMagia          As Long
 Public IntervaloUserPuedeCastear    As Long
 Public IntervaloTrabajarExtraer     As Long
 Public IntervaloNpcOwner            As Long
-
 Public IntervaloTrabajarConstruir   As Long
-
-Public IntervaloCerrarConexion      As Long '[Gonzalo]
-
+Public IntervaloCerrarConexion      As Long
 Public IntervaloUserPuedeUsarU      As Long
-
 Public IntervaloUserPuedeUsarClic   As Long
-
 Public IntervaloGolpeUsar           As Long
-
 Public IntervaloFlechasCazadores    As Long
-
 Public TimeoutPrimerPaquete         As Long
-
 Public TimeoutEsperandoLoggear      As Long
-
 Public IntervaloTirar               As Long
-
 Public IntervaloMeditar             As Long
-
 Public IntervaloCaminar             As Long
-
 Public IntervaloEnCombate           As Long
-
 Public IntervaloPuedeSerAtacado     As Long
-
 Public IntervaloGuardarUsuarios     As Long
-
 Public LimiteGuardarUsuarios        As Integer
-
 Public IntervaloTimerGuardarUsuarios As Integer
-
 Public IntervaloMensajeGlobal       As Long
-
 Public Const IntervaloConsultaGM    As Long = 300000
 
 'BALANCE
@@ -145,9 +122,9 @@ Public ExpLevelUp(1 To STAT_MAXELV) As Long
 Public InfluenciaPromedioVidas      As Single
 Public ModDañoGolpeCritico          As Single
 Public MinutosWs                    As Long
-Public PlayerStunTime               As Long
-Public NpcStunTime                  As Long
-Public PlayerInmuneTime             As Long
+Public PlayerStunTime               As Double
+Public NpcStunTime                  As Double
+Public PlayerInmuneTime             As Double
 Public MultiShotReduction           As Single
 Public HomeTimer                    As Integer
 Public MagicSkillBonusDamageModifier As Single

--- a/Codigo/CharacterPersistence.bas
+++ b/Codigo/CharacterPersistence.bas
@@ -481,8 +481,8 @@ End Sub
 Public Sub SaveCharacterDB(ByVal userIndex As Integer)
 
         On Error GoTo ErrorHandler
-        Dim PerformanceTimer As Long
-        Call PerformanceTestStart(PerformanceTimer)
+'        Dim PerformanceTimer As Long
+'        Call PerformanceTestStart(PerformanceTimer)
         Dim Params() As Variant
         Dim LoopC As Long
         Dim ParamC As Long
@@ -587,7 +587,7 @@ Public Sub SaveCharacterDB(ByVal userIndex As Integer)
             
             ' ************************** User inventory *********************************
             ReDim Params(MAX_INVENTORY_SLOTS * 5 - 1)
-            ParamC = 0            
+            ParamC = 0
 
 370         For LoopC = 1 To MAX_INVENTORY_SLOTS
 372             Params(ParamC) = .ID
@@ -751,7 +751,6 @@ Public Sub SaveCharacterDB(ByVal userIndex As Integer)
 
 626                 Call Builder.Clear
                 End If
-        Call PerformTimeLimitCheck(PerformanceTimer, "save character id:" & .id, 50)
         End With
         
         Exit Sub

--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -155,7 +155,8 @@ End Enum
 
 Public Md5Cliente           As String
 Public PrivateKey           As String
-Public HoraMundo            As Long
+Public HoraMundo            As Double
+Public GlobalFrameTime      As Double
 Public HoraActual           As Integer
 Public UltimoChar           As String
 Public ExpMult              As Integer
@@ -176,7 +177,7 @@ Public PENDIENTE            As Integer
 Public CostoPerdonPorCiudadano As Long
 Public MaximoSpeedHack      As Integer
 Public LastRecordUsuarios   As Integer
-Public GlobalFrameTime      As Long
+
 
 Public FISHING_REQUIRED_PERCENT As Integer
 Public FISHING_TILES_ON_MAP     As Integer
@@ -2178,7 +2179,7 @@ Public Type t_UserCounters
 
     ' Anticheat
     SpeedHackCounter As Single
-    LastStep As Long
+    LastStep As Double
     
     Invisibilidad As Integer
     DisabledInvisibility As Integer
@@ -2198,51 +2199,47 @@ Public Type t_UserCounters
     
     Maldicion As Byte
 
-    TimerLanzarSpell As Long
-    TimerPuedeAtacar As Long
-    TimerPuedeUsarArco As Long
-    TimerPuedeTrabajar As Long
-    TimerUsar As Long
-    TimerUsarClick As Long
-    TimerMagiaGolpe As Long
-    TimerGolpeMagia As Long
-    TimerGolpeUsar As Long
-    TimerCaminar As Long
-    TimerTirar As Long
-    TimerMeditar As Long
-    TiempoInicioMeditar As Long
-    'Nuevos de AoLibre
-    TimerPuedeSerAtacado As Long
-    TimerPerteneceNpc As Long
-
-    Trabajando As Long  ' Para el centinela
-    LastTrabajo As Integer
-    Ocultando As Long   ' Unico trabajo no revisado por el centinela
-
+    TimerLanzarSpell As Double
+    TimerPuedeAtacar As Double
+    TimerPuedeUsarArco As Double
+    TimerPuedeTrabajar As Double
+    TimerUsar As Double
+    TimerUsarClick As Double
+    TimerMagiaGolpe As Double
+    TimerGolpeMagia As Double
+    TimerGolpeUsar As Double
+    TimerCaminar As Double
+    TimerTirar As Double
+    TimerMeditar As Double
+    TiempoInicioMeditar As Double
+    TimerPuedeSerAtacado As Double
+    TimerPerteneceNpc As Double
+    Trabajando As Double
+    LastTrabajo As Double
+    Ocultando As Double
     goHome As Long
-
-    LastSave As Long
+    LastSave As Double
     
     CuentaRegresiva As Integer
     TimerBarra As Integer
-    LastResetTick As Long
-    LastTransferGold As Long
+    LastResetTick As Double
+    LastTransferGold As Double
     
 End Type
 
 Public Type t_UserIntervals
 
-    Magia As Long
-    Golpe As Long
-    Arco As Long
-    UsarU As Long
-    UsarClic As Long
-    Caminar As Long
-    GolpeMagia As Long
-    MagiaGolpe As Long
-    GolpeUsar As Long
-    TrabajarExtraer As Long
-    TrabajarConstruir As Long
+    Magia As Double
+    Golpe As Double
+    Arco As Double
+    UsarU As Double
+    UsarClic As Double
+    Caminar As Double
+    GolpeMagia As Double
+    MagiaGolpe As Double
+    GolpeUsar As Double
+    TrabajarExtraer As Double
+    TrabajarConstruir As Double
 
 End Type
 
@@ -2372,7 +2369,7 @@ Public Type t_ConnectionInfo
     IP As String
     ConnIDValida As Boolean
     ConnID As Long
-    OnConnectTimestamp As Long
+    OnConnectTimestamp As Double
 End Type
 
 Public Const HotKeyCount As Integer = 10
@@ -2430,7 +2427,7 @@ Public Type t_User
     Modifiers As t_ActiveModifiers
     flags As t_UserFlags
     Accion As t_AccionPendiente
-    CdTimes(e_CdTypes.CDCount) As Long
+    CdTimes(e_CdTypes.CDCount) As Double
     LastTransportNetwork As t_LastNetworkUssage
     EffectOverTime As t_EffectOverTimeList
 
@@ -2478,13 +2475,13 @@ Public Type t_User
     encrypted_session_token As String
     encrypted_session_token_db_id As Long
     
-    MacroIterations(1 To MAX_PACKET_COUNTERS) As Long
-    PacketTimers(1 To MAX_PACKET_COUNTERS) As Long
-    PacketCounters(1 To MAX_PACKET_COUNTERS) As Long
+    MacroIterations(1 To MAX_PACKET_COUNTERS) As Double
+    PacketTimers(1 To MAX_PACKET_COUNTERS) As Double
+    PacketCounters(1 To MAX_PACKET_COUNTERS) As Double
 End Type
 
-Public MacroIterations(1 To MAX_PACKET_COUNTERS) As Long
-Public PacketTimerThreshold(1 To MAX_PACKET_COUNTERS) As Long
+Public MacroIterations(1 To MAX_PACKET_COUNTERS) As Double
+Public PacketTimerThreshold(1 To MAX_PACKET_COUNTERS) As Double
     
 
 '*********************************************************
@@ -2517,16 +2514,16 @@ End Type
 
 Public Type t_NpcCounters
 
-    Paralisis              As Long
-    Inmovilizado           As Long
-    StunEndTime            As Long
-    TiempoExistencia       As Long
-    IntervaloAtaque        As Long
-    IntervaloMovimiento    As Long
-    IntervaloLanzarHechizo As Long
-    IntervaloRespawn       As Long
-    UltimoAtaque           As Long
-    CriaturasInvocadas     As Long
+    Paralisis              As Double
+    Inmovilizado           As Double
+    StunEndTime            As Double
+    TiempoExistencia       As Double
+    IntervaloAtaque        As Double
+    IntervaloMovimiento    As Double
+    IntervaloLanzarHechizo As Double
+    IntervaloRespawn       As Double
+    UltimoAtaque           As Double
+    CriaturasInvocadas     As Double
     
 End Type
 
@@ -3256,17 +3253,3 @@ Public Sub IncreaseLong(ByRef dest As Long, ByVal amount As Long)
     dest = dest + amount
 End Sub
 
-Public Sub PerformanceTestStart(ByRef Timer As Long)
-    Timer = GetTickCount()
-End Sub
-
-' Test the time since last call and update the time
-' log if there time betwen calls exced the limit
-Public Sub PerformTimeLimitCheck(ByRef timer As Long, ByRef TestText As String, Optional ByVal TimeLimit As Long = 1000)
-    Dim CurrTime As Long
-    CurrTime = GetTickCount() - timer
-    If CurrTime > TimeLimit Then
-        Call LogPerformance("Performance warning at: " & TestText & " elapsed time: " & CurrTime)
-    End If
-    timer = GetTickCount()
-End Sub

--- a/Codigo/EffectsOverTime.bas
+++ b/Codigo/EffectsOverTime.bas
@@ -27,7 +27,7 @@ Attribute VB_Name = "EffectsOverTime"
 '
 Option Explicit
 
-Private LastUpdateTime As Long
+Private LastUpdateTime As Double
 Private UniqueIdCounter As Long
 Const ACTIVE_EFFECTS_MIN_SIZE As Integer = 500
 Private ActiveEffects As t_EffectOverTimeList
@@ -70,8 +70,8 @@ End Sub
 
 Public Sub UpdateEffectOverTime()
 On Error GoTo Update_Err
-    Dim CurrTime As Long
-    Dim ElapsedTime As Long
+    Dim currTime As Double
+    Dim ElapsedTime As Double
 100 CurrTime = GetTickCount()
 102 If CurrTime < LastUpdateTime Then ' GetTickCount can overflow se we take care of that
 104     ElapsedTime = 0

--- a/Codigo/General.bas
+++ b/Codigo/General.bas
@@ -729,8 +729,6 @@ Sub Main()
         '           Configuracion de los sockets
         ' ----------------------------------------------------
     
-314     Call GetHoraActual
-    
 316     HoraMundo = GetTickCount() - DuracionDia \ 2
 
 318     frmCargando.Visible = False
@@ -760,23 +758,45 @@ Sub Main()
                     Call UnitClient.Connect("127.0.0.1", "7667")
         #End If
         
-            
+        Static time_dt As New clsElapsedTime
+    
         While (True)
             GlobalFrameTime = GetTickCount()
-            Dim PerformanceTimer As Long
-            Call PerformanceTestStart(PerformanceTimer)
-#If PYMMO = 1 Then
-            Call modNetwork.close_not_logged_sockets_if_timeout
-#End If
-            Call PerformTimeLimitCheck(PerformanceTimer, "General modNetwork.close_not_logged_sockets_if_timeout")
+    
+            time_dt.Start
+    #If PYMMO = 1 Then
+                Call modNetwork.close_not_logged_sockets_if_timeout
+    #End If
+            If time_dt.ElapsedTime > 1000 Then
+                Call LogPerformance("General modNetwork.close_not_logged_sockets_if_timeout: " & time_dt.ElapsedTime)
+            End If
+            
+            time_dt.Start
             Call modNetwork.Tick(GetElapsed())
-            Call PerformTimeLimitCheck(PerformanceTimer, "General modNetwork.Tick")
+            If time_dt.ElapsedTime > 1000 Then
+                Call LogPerformance("General modNetwork.Tick: " & time_dt.ElapsedTime)
+            End If
+            
+            
+            time_dt.Start
             Call UpdateEffectOverTime
-            Call PerformTimeLimitCheck(PerformanceTimer, "General Update Effects over time")
+            If time_dt.ElapsedTime > 1000 Then
+                Call LogPerformance("General Update Effects over time" & time_dt.ElapsedTime)
+            End If
+            
+            time_dt.Start
             DoEvents
-            Call PerformTimeLimitCheck(PerformanceTimer, "Do events")
+            If time_dt.ElapsedTime > 1000 Then
+                Call LogPerformance("Do events" & time_dt.ElapsedTime)
+            End If
+            
+            
+            time_dt.Start
             Call AntiCheatUpdate
-            Call PerformTimeLimitCheck(PerformanceTimer, "Update anti cheat")
+            If time_dt.ElapsedTime > 1000 Then
+                Call LogPerformance("AntiCheatUpdate" & time_dt.ElapsedTime)
+            End If
+            
             ' Unlock main loop for maximum throughput but it can hog weak CPUs.
             #If UNLOCK_CPU = 0 Then
                 Call Sleep(1)

--- a/Codigo/InstanceManager.bas
+++ b/Codigo/InstanceManager.bas
@@ -61,9 +61,7 @@ Public Sub CloneMapWithTranslations(ByVal SourceMapIndex As Integer, ByVal DestM
     MapInfo(DestMapIndex).MapResource = SourceMapIndex
     Dim PosX As Integer
     Dim PosY As Integer
-    Dim PerformanceTimer As Long
     Dim i As Integer
-    Call PerformanceTestStart(PerformanceTimer)
     For PosY = YMinMapSize To YMaxMapSize
         For PosX = XMinMapSize To XMaxMapSize
             MapData(DestMapIndex, PosX, PosY) = MapData(SourceMapIndex, PosX, PosY)
@@ -76,5 +74,4 @@ Public Sub CloneMapWithTranslations(ByVal SourceMapIndex As Integer, ByVal DestM
             End If
         Next PosX
     Next PosY
-    Call PerformTimeLimitCheck(PerformanceTimer, "CloneMapWithTranslations time", 50)
 End Sub

--- a/Codigo/ModAreas.bas
+++ b/Codigo/ModAreas.bas
@@ -123,23 +123,13 @@ End Sub
  
 Public Sub AreasOptimizacion()
         
-        On Error GoTo AreasOptimizacion_Err
+On Error GoTo AreasOptimizacion_Err
         
-
-        '**************************************************************
-        'Author: Lucio N. Tourrilhes (DuNga)
-        'Last Modify Date: Unknow
-        'Es la función de autooptimizacion.... la idea es no mandar redimensionando arrays grandes todo el tiempo
-        '**************************************************************
         Dim LoopC      As Long
-
         Dim tCurDay    As Byte
-
         Dim tCurHour   As Byte
-
         Dim EntryValue As Long
-        Dim PerformanceTimer As Long
-        Call PerformanceTestStart(PerformanceTimer)
+
 100     If (CurDay <> IIf(Weekday(Date) > 6, 1, 2)) Or (CurHour <> Fix(Hour(Time) \ 3)) Then
         
 102         tCurDay = IIf(Weekday(Date) > 6, 1, 2) 'A ke tipo de dia pertenece?
@@ -160,7 +150,6 @@ Public Sub AreasOptimizacion()
 
         End If
 
-        Call PerformTimeLimitCheck(PerformanceTimer, "ModAreas.AreasOptimizacion")
         Exit Sub
 
 AreasOptimizacion_Err:

--- a/Codigo/ModEventos.bas
+++ b/Codigo/ModEventos.bas
@@ -26,7 +26,6 @@ Attribute VB_Name = "ModEventos"
 '
 '
 '
-Public HoraEvento           As Byte
 
 Public TiempoRestanteEvento As Byte
 

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -3240,7 +3240,7 @@ Public Function CanMove(ByRef flags As t_UserFlags, ByRef Counters As t_UserCoun
 End Function
 
 Public Function StunPlayer(ByVal UserIndex As Integer, ByRef Counters As t_UserCounters) As Boolean
-    Dim currTime As Long
+    Dim currTime As Double
     StunPlayer = False
     If Not CanMove(UserList(UserIndex).flags, Counters) Then Exit Function
     If IsSet(UserList(UserIndex).flags.StatusMask, eCCInmunity) Then Exit Function
@@ -3363,7 +3363,7 @@ Public Function CanAttackUser(ByVal AttackerIndex As Integer, ByVal AttackerVers
     ' Nueva verificación específica para Captura la Bandera
     If UserList(attackerIndex).flags.jugando_captura = 1 And UserList(TargetIndex).flags.jugando_captura = 1 Then
         If UserList(attackerIndex).flags.CurrentTeam = UserList(TargetIndex).flags.CurrentTeam Then
-            Call WriteConsoleMsg(attackerIndex, "¡No puedes atacar a miembros de tu propio equipo!", e_FontTypeNames.FONTTYPE_INFO)
+            Call WriteConsoleMsg(AttackerIndex, "¡No puedes atacar a miembros de tu propio equipo!", e_FontTypeNames.FONTTYPE_INFO)
             CanAttackUser = eSameTeam
             Exit Function
         End If

--- a/Codigo/clsElapsedTime.cls
+++ b/Codigo/clsElapsedTime.cls
@@ -1,0 +1,58 @@
+VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+  Persistable = 0  'NotPersistable
+  DataBindingBehavior = 0  'vbNone
+  DataSourceBehavior  = 0  'vbNone
+  MTSTransactionMode  = 0  'NotAnMTSObject
+END
+Attribute VB_Name = "clsElapsedTime"
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Creatable = True
+Attribute VB_PredeclaredId = False
+Attribute VB_Exposed = False
+' Argentum 20 Game Server
+'
+'    Copyright (C) 2023 Noland Studios LTD
+'
+'    This program is free software: you can redistribute it and/or modify
+'    it under the terms of the GNU Affero General Public License as published by
+'    the Free Software Foundation, either version 3 of the License, or
+'    (at your option) any later version.
+'
+'    This program is distributed in the hope that it will be useful,
+'    but WITHOUT ANY WARRANTY; without even the implied warranty of
+'    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+'    GNU Affero General Public License for more details.
+'
+'    You should have received a copy of the GNU Affero General Public License
+'    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+'
+'    This program was based on Argentum Online 0.11.6
+'    Copyright (C) 2002 Márquez Pablo Ignacio
+'
+'    Argentum Online is based on Baronsoft's VB6 Online RPG
+'    You can contact the original creator of ORE at aaron@baronsoft.com
+'    for more information about ORE please visit http://www.baronsoft.com/
+'
+'
+'
+Option Explicit
+
+Private mStart As Double
+ 
+Public Sub Start()
+    mStart = GetTickCount()
+End Sub
+
+Public Function ElapsedTime() As Double
+    ' Test the time since last call and update the log if the elapsed time exceeds TimeLimit
+    ' This is used to debug the server and detect code too slow
+
+    ElapsedTime = GetTickCount() - mStart
+End Function
+
+
+Private Sub Class_Initialize()
+Call Me.Start
+End Sub

--- a/Codigo/modNuevoTimer.bas
+++ b/Codigo/modNuevoTimer.bas
@@ -300,17 +300,9 @@ IntervaloPermiteUsar_Err:
 
         
 End Function
-' USAR OBJETOS CON CLICK
 Public Function IntervaloPermiteUsarClick(ByVal UserIndex As Integer, Optional ByVal Actualizar As Boolean = True) As Boolean
-'**
-'Author: Unknown
-'Last Modification: 25/01/2010 (ZaMa)
-'25/01/2010: ZaMa - General adjustments.
-'**
-
-    Dim TActual As Long
-    TActual = GetTickCount() And &H7FFFFFFF
-
+    Dim TActual As Double
+    TActual = GetTickCount()
     If TActual - UserList(UserIndex).Counters.TimerUsarClick >= UserList(UserIndex).Intervals.UsarClic Then
         If Actualizar Then
             UserList(UserIndex).Counters.TimerUsarClick = TActual
@@ -383,29 +375,20 @@ IntervaloPermiteCaminar_Err:
 End Function
 
 Public Function IntervaloPermiteMoverse(ByVal NpcIndex As Integer) As Boolean
-        
-        On Error GoTo IntervaloPermiteMoverse_Err
-        
-
-        Dim TActual As Long
-
-100     TActual = GetTickCount()
-
-102     If TActual - NpcList(NpcIndex).Contadores.IntervaloMovimiento >= (NpcList(NpcIndex).IntervaloMovimiento / GetNpcSpeedModifiers(NpcIndex)) Then
-    
-            '  Call AddtoRichTextBox(frmMain.RecTxt, "Usar OK.", 255, 0, 0, True, False, False)
-104         NpcList(NpcIndex).Contadores.IntervaloMovimiento = TActual
-106         IntervaloPermiteMoverse = True
-        Else
-108         IntervaloPermiteMoverse = False
-
-        End If
-
-        
-        Exit Function
+ On Error GoTo IntervaloPermiteMoverse_Err
+      
+      Dim TActual As Double
+      TActual = GetTickCount()
+      If TActual - NpcList(NpcIndex).Contadores.IntervaloMovimiento >= (NpcList(NpcIndex).IntervaloMovimiento / GetNpcSpeedModifiers(NpcIndex)) Then
+         NpcList(NpcIndex).Contadores.IntervaloMovimiento = TActual
+         IntervaloPermiteMoverse = True
+      Else
+         IntervaloPermiteMoverse = False
+      End If
+      Exit Function
 
 IntervaloPermiteMoverse_Err:
-110     Call TraceError(Err.Number, Err.Description, "modNuevoTimer.IntervaloPermiteMoverse", Erl)
+     Call TraceError(Err.Number, Err.Description, "modNuevoTimer.IntervaloPermiteMoverse", Erl)
 
         
 End Function
@@ -435,8 +418,7 @@ Public Function IntervaloPermiteAtacarNPC(ByVal NpcIndex As Integer) As Boolean
 100     TActual = GetTickCount()
 
 102     If TActual - NpcList(NpcIndex).Contadores.IntervaloAtaque >= NpcList(NpcIndex).IntervaloAtaque Then
-    
-            '  Call AddtoRichTextBox(frmMain.RecTxt, "Usar OK.", 255, 0, 0, True, False, False)
+ 
 104         NpcList(NpcIndex).Contadores.IntervaloAtaque = TActual
 106         IntervaloPermiteAtacarNPC = True
         Else

--- a/Codigo/modTime.bas
+++ b/Codigo/modTime.bas
@@ -28,11 +28,12 @@ Attribute VB_Name = "modTime"
 '
 Option Explicit
 
+Private Declare Function GetTickCount64 Lib "kernel32.dll" () As Currency
+
 Private Declare Function timeGetTime Lib "winmm.dll" () As Long
 Private Declare Sub GetSystemTime Lib "kernel32.dll" (lpSystemTime As t_SYSTEMTIME)
 
 Private theTime      As t_SYSTEMTIME
-
 
 Private Type t_SYSTEMTIME
 
@@ -53,43 +54,11 @@ Public Type t_Timer
     Occurrences As Integer
 End Type
 
-Public Function GetTickCount() As Long
-        On Error GoTo GetTickCount_Err
-        GetTickCount = timeGetTime And &H7FFFFFFF
-        Exit Function
-GetTickCount_Err:
-        Call TraceError(Err.Number, Err.Description, "ModLadder.GetTickCount", Erl)
-End Function
 
-Function GetTimeFormated() As String
-        On Error GoTo GetTimeFormated_Err
-        Dim Elapsed As Long
-        Elapsed = (GetTickCount() - HoraMundo) / DuracionDia
-        Dim Mins As Long
-        Mins = (Elapsed - Fix(Elapsed)) * 1440
-        Dim Horita    As Byte
-        Dim Minutitos As Byte
-        Horita = Fix(Mins / 60)
-        Minutitos = Mins Mod 60
-        GetTimeFormated = Right$("00" & Horita, 2) & ":" & Right$("00" & Minutitos, 2)
-        Exit Function
-GetTimeFormated_Err:
-     Call TraceError(Err.Number, Err.Description, "ModLadder.GetTimeFormated - " + Erl, Erl)
+Public Function GetTickCount() As Double
+    GetTickCount = GetTickCount64 * 10000
+    Exit Function
 End Function
-
-Public Sub GetHoraActual()
-        On Error GoTo GetHoraActual_Err
-        GetSystemTime theTime
-        HoraActual = (theTime.wHour - 3)
-        If HoraActual = -3 Then HoraActual = 21
-        If HoraActual = -2 Then HoraActual = 22
-        If HoraActual = -1 Then HoraActual = 23
-        frmMain.lblhora.Caption = HoraActual & ":" & Format(theTime.wMinute, "00") & ":" & Format(theTime.wSecond, "00")
-        HoraEvento = HoraActual
-        Exit Sub
-GetHoraActual_Err:
-     Call TraceError(Err.Number, Err.Description, "ModLadder.GetHoraActual", Erl)
-End Sub
 
 Public Function SumarTiempo(segundos As Integer) As String
         On Error GoTo SumarTiempo_Err
@@ -107,7 +76,7 @@ Public Function SumarTiempo(segundos As Integer) As String
         SumarTiempo = T 'a la funcion le damos el valor que hallamos en T
         Exit Function
 SumarTiempo_Err:
-     Call TraceError(Err.Number, Err.Description, "ModLadder.SumarTiempo", Erl)
+     Call TraceError(Err.Number, Err.Description, "modTime.SumarTiempo", Erl)
 End Function
 
 Public Sub SetTimer(ByRef timer As t_Timer, ByVal Interval As Long)

--- a/Server.VBP
+++ b/Server.VBP
@@ -123,6 +123,7 @@ Class=IInventoryInterface; Codigo\Scenearios\IInventoryInterface.cls
 Module=PacketId; Codigo\PacketId.bas
 Module=AntiCheat; Codigo\AntiCheat.bas
 Module=InstanceManager; Codigo\InstanceManager.bas
+Class=clsElapsedTime; Codigo\clsElapsedTime.cls
 IconForm="frmMain"
 Startup="Sub Main"
 HelpFile=""


### PR DESCRIPTION
La idea es cambiar la función `GetTickCount` por `GetTickCount64`, que sólo está disponible en sistemas de 64 bits pero tiene límites de tiempo más altos (los de la versión de 32 bits rondan los 49 días, pero considerando que VB6 no tiene variables de tipo unsigned, puede que estemos usando sólo la mitad de ese límite).

Esto puede ser una posible solución a https://github.com/ao-org/argentum-online-server/issues/664, pero dada la poca información que tenemos al respecto, lo mejor sería probar la solución unos días y verificar si el error vuelve a suceder. Si pasa, vamos a necesitar poner más logs y revisiones para ver dónde se está generando el error y por qué.

**IMPORTANTE:** hay que verificar que el código compile y que el servidor arranque correctamente antes de deployar este cambio.
