### PR TITLE
Various fixes for DirectPlay

### DIFF
--- a/Codigo/General.bas
+++ b/Codigo/General.bas
@@ -870,9 +870,9 @@ End Function
 
 Sub MostrarNumUsers()
 On Error GoTo MostrarNumUsers_Err
-        'Call SendData(SendTarget.ToAll, 0, PrepareMessageOnlineUser(NumUsers))
+        Call SendData(SendTarget.ToAll, 0, PrepareMessageOnlineUser(NumUsers))
         frmMain.CantUsuarios.Caption = "Numero de usuarios jugando: " & NumUsers
-         Exit Sub
+        Exit Sub
 
 MostrarNumUsers_Err:
 106     Call TraceError(Err.Number, Err.Description, "General.MostrarNumUsers", Erl)

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -228,8 +228,8 @@ On Error GoTo Check_ConnectUser_Err
         End If
         
         If EsGM(UserIndex) Then
-            Call SendData(SendTarget.ToAdmins, 0, PrepareMessageConsoleMsg("Servidor » " & name & " se conecto al juego.", e_FontTypeNames.FONTTYPE_INFOBOLD))
-            Call LogGM(name, "Se conectó con IP: " & .ConnectionDetails.IP)
+            Call SendData(SendTarget.ToAdmins, 0, PrepareMessageConsoleMsg("Servidor » " & Name & " se conecto al juego.", e_FontTypeNames.FONTTYPE_INFOBOLD))
+            Call LogGM(Name, "Se conectó con IP: " & .ConnectionDetails.IP)
         End If
     End With
     
@@ -799,7 +799,7 @@ On Error GoTo Complete_ConnectUser_Err
 
 
 1135        ElseIf .Stats.ELV < 14 Then
-1140            Call WriteConsoleMsg(UserIndex, "¡Bienvenido de nuevo " & .name & "! Actualmente estas en el nivel " & .Stats.ELV & " en " & get_map_name(.pos.Map) & ", ¡buen viaje y mucha suerte!", e_FontTypeNames.FONTTYPE_GUILD)
+1140            Call WriteConsoleMsg(UserIndex, "¡Bienvenido de nuevo " & .Name & "! Actualmente estas en el nivel " & .Stats.ELV & " en " & get_map_name(.pos.Map) & ", ¡buen viaje y mucha suerte!", e_FontTypeNames.FONTTYPE_GUILD)
 
              End If
 
@@ -1204,8 +1204,16 @@ Sub MakeUserChar(ByVal toMap As Boolean, _
 138                         TempName = .NameMimetizado
                         End If
                     End If
+                    
 
-140                 Call WriteCharacterCreate(sndIndex, .Char.body, .Char.head, .Char.Heading, .Char.charindex, x, y, .Char.WeaponAnim, .Char.ShieldAnim, .Char.CartAnim, .Char.FX, 999, .Char.CascoAnim, TempName, .Faccion.Status, .flags.Privilegios, .Char.ParticulaFx, .Char.Head_Aura, .Char.Arma_Aura, .Char.Body_Aura, .Char.DM_Aura, .Char.RM_Aura, .Char.Otra_Aura, .Char.Escudo_Aura, .Char.speeding, 0, appear, .Grupo.Lider.ArrayIndex, .GuildIndex, clan_nivel, .Stats.MinHp, .Stats.MaxHp, .Stats.MinMAN, .Stats.MaxMAN, 0, False, .flags.Navegando, .Stats.tipoUsuario, .flags.CurrentTeam, .flags.tiene_bandera)
+                                    
+140                 Call WriteCharacterCreate(sndIndex, _
+                                    .Char.body, .Char.head, .Char.Heading, .Char.charindex, x, y, .Char.WeaponAnim, .Char.ShieldAnim, .Char.CartAnim, _
+                                    .Char.FX, 999, .Char.CascoAnim, TempName, .Faccion.Status, .flags.Privilegios, .Char.ParticulaFx, _
+                                    .Char.Head_Aura, .Char.Arma_Aura, .Char.Body_Aura, .Char.DM_Aura, .Char.RM_Aura, .Char.Otra_Aura, _
+                                    .Char.Escudo_Aura, .Char.speeding, 0, appear, .Grupo.Lider.ArrayIndex, .GuildIndex, clan_nivel, _
+                                    .Stats.MinHp, .Stats.MaxHp, .Stats.MinMAN, .Stats.MaxMAN, 0, False, .flags.Navegando, _
+                                    .Stats.tipoUsuario, .flags.CurrentTeam, .flags.tiene_bandera)
                     
                 Else
             
@@ -3572,10 +3580,10 @@ On Error GoTo DoDamageOrHeal_Err
         DamageStr = PonerPuntos(Math.Abs(Amount))
         If SourceType = eUser Then
             If UserList(SourceIndex).ChatCombate = 1 And DoDamageText > 0 Then
-                Call WriteLocaleMsg(SourceIndex, DoDamageText, e_FontTypeNames.FONTTYPE_FIGHT, UserList(UserIndex).name & "¬" & DamageStr)
+                Call WriteLocaleMsg(SourceIndex, DoDamageText, e_FontTypeNames.FONTTYPE_FIGHT, UserList(UserIndex).Name & "¬" & DamageStr)
             End If
             If UserList(UserIndex).ChatCombate = 1 And GotDamageText > 0 Then
-                Call WriteLocaleMsg(UserIndex, GotDamageText, e_FontTypeNames.FONTTYPE_FIGHT, UserList(SourceIndex).name & "¬" & DamageStr)
+                Call WriteLocaleMsg(UserIndex, GotDamageText, e_FontTypeNames.FONTTYPE_FIGHT, UserList(SourceIndex).Name & "¬" & DamageStr)
             End If
         End If
         amount = EffectsOverTime.TargetApplyDamageReduction(UserList(UserIndex).EffectOverTime, amount, SourceIndex, SourceType, DamageSourceType)

--- a/Codigo/Protocol_Writes.bas
+++ b/Codigo/Protocol_Writes.bas
@@ -5041,8 +5041,8 @@ Public Function PrepareMessageHora()
         On Error GoTo PrepareMessageHora_Err
         '</EhHeader>
 100     Call Writer.WriteInt16(ServerPacketID.eHora)
-102     Call Writer.WriteInt32((GetTickCount() - HoraMundo) Mod SvrConfig.GetValue("DayLength"))
-104     Call Writer.WriteInt32(SvrConfig.GetValue("DayLength"))
+102     Call Writer.WriteInt32(CLng((GetTickCount() - HoraMundo) Mod CLng(SvrConfig.GetValue("DayLength"))))
+104     Call Writer.WriteInt32(CLng(SvrConfig.GetValue("DayLength")))
         '<EhFooter>
         Exit Function
 

--- a/Codigo/TCP.bas
+++ b/Codigo/TCP.bas
@@ -852,7 +852,7 @@ ErrHandler:
 
 End Sub
 
-'[Alejo-21-5]: Cierra un socket sin limpiar el slot
+
 Sub CloseSocketSL(ByVal UserIndex As Integer)
         
         On Error GoTo CloseSocketSL_Err
@@ -1737,7 +1737,7 @@ Sub ClearAndSaveUser(ByVal UserIndex As Integer)
                 Call WriteUserCharIndexInServer(.flags.GMMeSigue.ArrayIndex)
                 Call UpdateUserInv(True, .flags.GMMeSigue.ArrayIndex, 1)
                 Call WriteUpdateUserStats(.flags.GMMeSigue.ArrayIndex)
-                Call WriteConsoleMsg(.flags.GMMeSigue.ArrayIndex, "El usuario " & UserList(UserIndex).name & " que estabas siguiendo se desconectó.", e_FontTypeNames.FONTTYPE_INFO)
+                Call WriteConsoleMsg(.flags.GMMeSigue.ArrayIndex, "El usuario " & UserList(UserIndex).Name & " que estabas siguiendo se desconectó.", e_FontTypeNames.FONTTYPE_INFO)
                 Call SetUserRef(.flags.GMMeSigue, 0)
                 'Falta revertir inventario del GM
             End If

--- a/Codigo/UnitClient.bas
+++ b/Codigo/UnitClient.bas
@@ -27,6 +27,8 @@ Attribute VB_Name = "UnitClient"
 '
 Option Explicit
 
+#If UNIT_TEST = 1 Then
+
 Public Enum ClientTests
     TestInvalidBigPacketID = 100
     TestInvalidNegativePacketID
@@ -199,4 +201,4 @@ Private Sub OnClientRecv(ByVal Message As Network.Reader)
     
 End Sub
 
-
+#End If

--- a/Codigo/UnitTesting.bas
+++ b/Codigo/UnitTesting.bas
@@ -26,6 +26,7 @@ Attribute VB_Name = "UnitTesting"
 '
 '
 Option Explicit
+#If UNIT_TEST = 1 Then
 
 Public public_key As String
 Public private_key As String
@@ -188,3 +189,4 @@ Function test_suite() As Boolean
     test_suite = result
 End Function
 
+#End If

--- a/Codigo/Unit_Protocol_Writes.bas
+++ b/Codigo/Unit_Protocol_Writes.bas
@@ -26,6 +26,7 @@ Attribute VB_Name = "Unit_Protocol_Writes"
 '
 '
 Option Explicit
+#If UNIT_TEST = 1 Then
 Private Writer As Network.Writer
 
 Public Function writer_is_nothing() As Boolean
@@ -110,3 +111,4 @@ End Sub
 
 
 
+#End If

--- a/Codigo/clsNetReader.cls
+++ b/Codigo/clsNetReader.cls
@@ -48,10 +48,13 @@ End Sub
 Public Function ReadInt16() As Integer
     Call GetDataFromBuffer(rcv_data.ReceivedData, ReadInt16, SIZE_INTEGER, loffset)
 End Function
-Public Function ReadBool() As Integer
+Public Function ReadInt32() As Long
+    Call GetDataFromBuffer(rcv_data.ReceivedData, ReadInt32, SIZE_LONG, lOffset)
+End Function
+Public Function ReadBool() As Boolean
     Call GetDataFromBuffer(rcv_data.ReceivedData, ReadBool, SIZE_BOOLEAN, lOffset)
 End Function
-Public Function ReadReal32() As Integer
+Public Function ReadReal32() As Single
     Call GetDataFromBuffer(rcv_data.ReceivedData, ReadReal32, SIZE_SINGLE, lOffset)
 End Function
 Public Function ReadInt8() As Byte

--- a/Codigo/clsNetWriter.cls
+++ b/Codigo/clsNetWriter.cls
@@ -40,7 +40,7 @@ End Sub
 Public Sub WriteInt16(ByVal v As Integer)
     AddDataToBuffer oMsg, v, SIZE_INTEGER, lOffset
 End Sub
-Public Sub WriteInt32(ByVal v As Integer)
+Public Sub WriteInt32(ByVal V As Long)
     AddDataToBuffer oMsg, v, SIZE_LONG, lOffset
 End Sub
 Public Sub WriteReal32(ByVal v As Single)
@@ -55,7 +55,7 @@ End Sub
 Public Sub Send(ByVal idSend As Long)
 On Error GoTo send_error
     
-    dps.sendto idSend, oMsg, 0, DPNSEND_GUARANTEED Or DPNSEND_NOLOOPBACK Or DPNSEND_GUARANTEED
+    dps.sendto idSend, oMsg, 0, DPNSEND_GUARANTEED Or DPNSEND_NOLOOPBACK Or DPNSEND_PRIORITY_HIGH
     Me.Clear
     
     Exit Sub
@@ -74,6 +74,11 @@ send_error:
 
 End Sub
 Public Sub WriteString8(ByVal v As String)
+    Debug.Assert Len(V) > 0
+    If Len(V) = 0 Then
+        ' this is a workaround because the game is trying to send empty strings and DP will crash if we call AddStringToBuffer with an empty str
+        V = "0"
+    End If
     AddStringToBuffer oMsg, v, lOffset
 End Sub
 Private Sub Class_Initialize()

--- a/Codigo/frmMain.frm
+++ b/Codigo/frmMain.frm
@@ -646,10 +646,12 @@ End Sub
 
 Private Sub DirectPlay8Event_AppDesc(fRejectMsg As Boolean)
     'VB requires that we must implement *every* member of this interface
+    Debug.Print "DirectPlay8Event_AppDesc"
 End Sub
 
 Private Sub DirectPlay8Event_AsyncOpComplete(dpnotify As DxVBLibA.DPNMSG_ASYNC_OP_COMPLETE, fRejectMsg As Boolean)
     'VB requires that we must implement *every* member of this interface
+    Debug.Print "DirectPlay8Event_AsyncOpComplete"
 End Sub
 
 Private Sub DirectPlay8Event_ConnectComplete(dpnotify As DxVBLibA.DPNMSG_CONNECT_COMPLETE, fRejectMsg As Boolean)
@@ -670,27 +672,34 @@ Private Sub DirectPlay8Event_DestroyGroup(ByVal lGroupID As Long, ByVal lReason 
 End Sub
 
 Private Sub DirectPlay8Event_DestroyPlayer(ByVal lPlayerID As Long, ByVal lReason As Long, fRejectMsg As Boolean)
+    Debug.Print "DirectPlay8Event_DestroyPlayer"
     Call modNetwork.DestroyPlayer(lPlayerID, lReason, fRejectMsg)
+    
 End Sub
 
 Private Sub DirectPlay8Event_EnumHostsQuery(dpnotify As DxVBLibA.DPNMSG_ENUM_HOSTS_QUERY, fRejectMsg As Boolean)
     'VB requires that we must implement *every* member of this interface
+     Debug.Print "DirectPlay8Event_EnumHostsQuery"
 End Sub
 
 Private Sub DirectPlay8Event_EnumHostsResponse(dpnotify As DxVBLibA.DPNMSG_ENUM_HOSTS_RESPONSE, fRejectMsg As Boolean)
     'VB requires that we must implement *every* member of this interface
+     Debug.Print "DirectPlay8Event_EnumHostsResponse"
 End Sub
 
 Private Sub DirectPlay8Event_HostMigrate(ByVal lNewHostID As Long, fRejectMsg As Boolean)
     'VB requires that we must implement *every* member of this interface
+     Debug.Print "DirectPlay8Event_HostMigrate"
 End Sub
 
 Private Sub DirectPlay8Event_IndicateConnect(dpnotify As DxVBLibA.DPNMSG_INDICATE_CONNECT, fRejectMsg As Boolean)
     'VB requires that we must implement *every* member of this interface
+    Debug.Print "DirectPlay8Event_IndicateConnect"
 End Sub
 
 Private Sub DirectPlay8Event_IndicatedConnectAborted(fRejectMsg As Boolean)
     'VB requires that we must implement *every* member of this interface
+     Debug.Print "DirectPlay8Event_IndicatedConnectAborted"
 End Sub
 
 Private Sub DirectPlay8Event_InfoNotify(ByVal lMsgID As Long, ByVal lNotifyID As Long, fRejectMsg As Boolean)

--- a/Codigo/modSendData.bas
+++ b/Codigo/modSendData.bas
@@ -29,7 +29,6 @@ Attribute VB_Name = "modSendData"
 Option Explicit
 
 Public Enum SendTarget
-
     ToAll = 1
     ToIndex
     toMap
@@ -89,8 +88,6 @@ End Sub
 
 Public Sub SendData(ByVal sndRoute As SendTarget, ByVal sndIndex As Integer, Optional Args As Variant, Optional ByVal validateInvi As Boolean = False)
 On Error GoTo SendData_Err
-
-    
     
 #If DIRECT_PLAY = 0 Then
      Dim buffer As Network.writer
@@ -312,16 +309,13 @@ SendData_Err:
         End If
 End Sub
 
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToUserAliveArea(ByVal UserIndex As Integer, ByVal Buffer As Network.Writer, Optional ByVal validateInvi As Boolean = False)
-        
-        On Error GoTo SendToUserArea_Err
-        
+#Else
+Private Sub SendToUserAliveArea(ByVal UserIndex As Integer, ByVal Buffer As clsNetWriter, Optional ByVal ValidateInvi As Boolean = False)
+#End If
+On Error GoTo SendToUserArea_Err
 
-        '**************************************************************
-        'Author: Lucio N. Tourrilhes (DuNga)
-        'Last Modify Date: Unknow
-        '
-        '**************************************************************
         Dim LoopC     As Long
         Dim tempIndex As Integer
         Dim map       As Integer
@@ -378,7 +372,12 @@ SendToUserArea_Err:
 
         
 End Sub
+
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToUserArea(ByVal UserIndex As Integer, ByVal Buffer As Network.Writer, Optional ByVal validateInvi As Boolean)
+#Else
+Private Sub SendToUserArea(ByVal UserIndex As Integer, ByVal Buffer As clsNetWriter, Optional ByVal ValidateInvi As Boolean)
+#End If
         
         On Error GoTo SendToUserArea_Err
 
@@ -438,8 +437,11 @@ SendToUserArea_Err:
         
 End Sub
 
-
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToUserAreaButFollowerAndIndex(ByVal UserIndex As Integer, ByVal Buffer As Network.Writer)
+#Else
+Private Sub SendToUserAreaButFollowerAndIndex(ByVal UserIndex As Integer, ByVal Buffer As clsNetWriter)
+#End If
 On Error GoTo SendToUserAreaButFollower_Err
         Dim LoopC     As Long
         Dim tempIndex As Integer
@@ -482,7 +484,11 @@ SendToUserAreaButFollower_Err:
         
 End Sub
 
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToPCDeadArea(ByVal UserIndex As Integer, ByVal Buffer As Network.Writer)
+#Else
+Private Sub SendToPCDeadArea(ByVal UserIndex As Integer, ByVal Buffer As clsNetWriter)
+#End If
  On Error GoTo SendToUserArea_Err
         Dim LoopC     As Long
         Dim tempIndex As Integer
@@ -527,17 +533,14 @@ SendToUserArea_Err:
         
 End Sub
 
-
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToPCDeadAreaButIndex(ByVal UserIndex As Integer, ByVal Buffer As Network.Writer)
+#Else
+Private Sub SendToPCDeadAreaButIndex(ByVal UserIndex As Integer, ByVal Buffer As clsNetWriter)
+#End If
         
-        On Error GoTo SendToUserArea_Err
-        
+On Error GoTo SendToUserArea_Err
 
-        '**************************************************************
-        'Author: Jopi
-        'Last Modify Date: 23/06/2021
-        'Envio la data a los que estan muertos y a los GMs en el area.
-        '**************************************************************
         Dim LoopC     As Long
         Dim tempIndex As Integer
         Dim Map       As Integer
@@ -579,15 +582,13 @@ SendToUserArea_Err:
 End Sub
 
 
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToSuperioresArea(ByVal UserIndex As Integer, ByVal Buffer As Network.Writer)
+#Else
+Private Sub SendToSuperioresArea(ByVal UserIndex As Integer, ByVal Buffer As clsNetWriter)
+#End If
+On Error GoTo SendToSuperioresArea_Err
         
-        On Error GoTo SendToSuperioresArea_Err
-
-        '**************************************************************
-        'Author: Jopi
-        'Last Modify Date: 27/12/2020
-        '
-        '**************************************************************
         Dim LoopC     As Long
         Dim TempInt   As Integer
         Dim tempIndex As Integer
@@ -636,16 +637,15 @@ SendToSuperioresArea_Err:
         
 End Sub
 
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToUserAreaButindex(ByVal UserIndex As Integer, ByVal Buffer As Network.Writer, Optional ByVal validateInvi As Boolean = False)
+#Else
+Private Sub SendToUserAreaButindex(ByVal UserIndex As Integer, ByVal Buffer As clsNetWriter, Optional ByVal ValidateInvi As Boolean = False)
+#End If
         
-        On Error GoTo SendToUserAreaButindex_Err
+On Error GoTo SendToUserAreaButindex_Err
         
 
-        '**************************************************************
-        'Author: Lucio N. Tourrilhes (DuNga)
-        'Last Modify Date: Unknow
-        '
-        '**************************************************************
         Dim LoopC     As Long
         Dim TempInt   As Integer
         Dim tempIndex As Integer
@@ -710,7 +710,11 @@ SendToUserAreaButindex_Err:
         
 End Sub
 
+#If DIRECT_PLAY = 0 Then
 Private Function CanSendToUser(ByRef SourceUser As t_User, ByRef TargetUser As t_User, ByVal TargetIndex As Integer, ByRef Buffer As Network.Writer, ByVal ValidateInvi As Boolean) As Boolean
+#Else
+Private Function CanSendToUser(ByRef SourceUser As t_User, ByRef TargetUser As t_User, ByVal TargetIndex As Integer, ByRef Buffer As clsNetWriter, ByVal ValidateInvi As Boolean) As Boolean
+#End If
     If (TargetUser.AreasInfo.AreaReciveX And SourceUser.AreasInfo.AreaPerteneceX) = 0 Then Exit Function
     If (TargetUser.AreasInfo.AreaReciveY And SourceUser.AreasInfo.AreaPerteneceY) = 0 Then Exit Function
     If Not TargetUser.ConnectionDetails.ConnIDValida Then Exit Function
@@ -739,16 +743,12 @@ Public Function CheckGuildSend(ByRef SourceUser As t_User, ByRef TargetUser As t
     CheckGuildSend = True
 End Function
 
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToUserAliveAreaButindex(ByVal UserIndex As Integer, ByRef Buffer As Network.Writer, Optional ByVal ValidateInvi As Boolean = False)
-        
-        On Error GoTo SendToUserAliveAreaButindex_Err
-        
-
-        '**************************************************************
-        'Author: Lucio N. Tourrilhes (DuNga)
-        'Last Modify Date: Unknow
-        '
-        '**************************************************************
+#Else
+Private Sub SendToUserAliveAreaButindex(ByVal UserIndex As Integer, ByRef Buffer As clsNetWriter, Optional ByVal ValidateInvi As Boolean = False)
+#End If
+On Error GoTo SendToUserAliveAreaButindex_Err
         Dim LoopC     As Long
         Dim tempIndex As Integer
         Dim Map       As Integer
@@ -772,16 +772,13 @@ Private Sub SendToUserAliveAreaButindex(ByVal UserIndex As Integer, ByRef Buffer
 SendToUserAliveAreaButindex_Err:
 124     Call TraceError(Err.Number, Err.Description, "modSendData.SendToUserAliveAreaButindex", Erl)
 End Sub
-Private Sub SendToAdminAreaButIndex(ByVal UserIndex As Integer, ByVal Buffer As Network.Writer)
-        
-        On Error GoTo SendToUserAreaButindex_Err
-        
 
-        '**************************************************************
-        'Author: Lucio N. Tourrilhes (DuNga)
-        'Last Modify Date: Unknow
-        '
-        '**************************************************************
+#If DIRECT_PLAY = 0 Then
+Private Sub SendToAdminAreaButIndex(ByVal UserIndex As Integer, ByVal Buffer As Network.Writer)
+#Else
+Private Sub SendToAdminAreaButIndex(ByVal UserIndex As Integer, ByVal Buffer As clsNetWriter)
+#End If
+On Error GoTo SendToUserAreaButindex_Err
         Dim LoopC     As Long
         Dim TempInt   As Integer
         Dim tempIndex As Integer
@@ -794,7 +791,6 @@ Private Sub SendToAdminAreaButIndex(ByVal UserIndex As Integer, ByVal Buffer As 
 102     Map = UserList(UserIndex).Pos.Map
 104     AreaX = UserList(UserIndex).AreasInfo.AreaPerteneceX
 106     AreaY = UserList(UserIndex).AreasInfo.AreaPerteneceY
-        'sndData = sndData & ENDC
 
 108     If Not MapaValido(Map) Then Exit Sub
     
@@ -834,16 +830,13 @@ SendToUserAreaButindex_Err:
         
 End Sub
 
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToUserAreaButGMs(ByVal UserIndex As Integer, ByVal Buffer As Network.Writer)
+#Else
+Private Sub SendToUserAreaButGMs(ByVal UserIndex As Integer, ByVal Buffer As clsNetWriter)
+#End If
         
         On Error GoTo SendToUserAreaButindex_Err
-        
-
-        '**************************************************************
-        'Author: Lucio N. Tourrilhes (DuNga)
-        'Last Modify Date: Unknow
-        '
-        '**************************************************************
         Dim LoopC     As Long
         
         Dim TempInt   As Integer
@@ -896,17 +889,12 @@ SendToUserAreaButindex_Err:
         
 End Sub
 
-
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToUserGuildArea(ByVal UserIndex As Integer, ByVal Buffer As Network.Writer)
-        
-        On Error GoTo SendToUserGuildArea_Err
-        
-
-        '**************************************************************
-        'Author: Juan  Martín Sotuyo Dodero (Maraxus)
-        'Last Modify Date: Unknow
-        '
-        '**************************************************************
+#Else
+Private Sub SendToUserGuildArea(ByVal UserIndex As Integer, ByVal Buffer As clsNetWriter)
+#End If
+On Error GoTo SendToUserGuildArea_Err
         Dim LoopC     As Long
         Dim tempIndex As Integer
         Dim Map       As Integer
@@ -949,17 +937,12 @@ SendToUserGuildArea_Err:
         
 End Sub
 
-
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToNpcArea(ByVal NpcIndex As Long, ByVal Buffer As Network.Writer)
-        
-        On Error GoTo SendToNpcArea_Err
-        
-
-        '**************************************************************
-        'Author: Lucio N. Tourrilhes (DuNga)
-        'Last Modify Date: Unknow
-        '
-        '**************************************************************
+#Else
+Private Sub SendToNpcArea(ByVal NpcIndex As Long, ByVal Buffer As clsNetWriter)
+#End If
+On Error GoTo SendToNpcArea_Err
         Dim LoopC     As Long
         Dim TempInt   As Integer
         Dim tempIndex As Integer
@@ -1007,17 +990,12 @@ SendToNpcArea_Err:
 
         
 End Sub
-
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToNpcAliveArea(ByVal NpcIndex As Long, ByVal Buffer As Network.Writer)
-        
-        On Error GoTo SendToNpcArea_Err
-        
-
-        '**************************************************************
-        'Author: Lucio N. Tourrilhes (DuNga)
-        'Last Modify Date: Unknow
-        '
-        '**************************************************************
+#Else
+Private Sub SendToNpcAliveArea(ByVal NpcIndex As Long, ByVal Buffer As clsNetWriter)
+#End If
+On Error GoTo SendToNpcArea_Err
         Dim LoopC     As Long
         Dim TempInt   As Integer
         Dim tempIndex As Integer
@@ -1079,9 +1057,14 @@ Public Sub SendToAreaByPos(ByVal Map As Integer, ByVal AreaX As Integer, ByVal A
 102     AreaY = 2 ^ (AreaY \ 12)
    
 104     If Not MapaValido(Map) Then Exit Sub
-      
+
+#If DIRECT_PLAY = 0 Then
         Dim Buffer As Network.Writer
         Set Buffer = Protocol_Writes.GetWriterBuffer()
+#Else
+        Dim Buffer As clsNetWriter
+        Set Buffer = Protocol_Writes.Writer
+#End If
         
 106     For LoopC = 1 To ConnGroups(Map).CountEntrys
 108         tempIndex = ConnGroups(Map).UserEntrys(LoopC)
@@ -1114,22 +1097,15 @@ SendToAreaByPos_Err:
 124         Call TraceError(Err.Number, Err.Description, "modSendData.SendToAreaByPos", Erl)
         End If
 End Sub
-
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToMap(ByVal Map As Integer, ByVal Buffer As Network.Writer)
-        
-        On Error GoTo SendToMap_Err
-        
-        '**************************************************************
-        'Author: Juan  Martín Sotuyo Dodero (Maraxus)
-        'Last Modify Date: 5/24/2007
-        '
-        '**************************************************************
+#Else
+Private Sub SendToMap(ByVal Map As Integer, ByVal Buffer As clsNetWriter)
+#End If
+On Error GoTo SendToMap_Err
         Dim LoopC     As Long
-
         Dim tempIndex As Integer
-    
 100     If Not MapaValido(Map) Then Exit Sub
-
 102     For LoopC = 1 To ConnGroups(Map).CountEntrys
 104         tempIndex = ConnGroups(Map).UserEntrys(LoopC)
         
@@ -1150,17 +1126,13 @@ SendToMap_Err:
 
         
 End Sub
-
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToMapButIndex(ByVal UserIndex As Integer, ByVal Buffer As Network.Writer)
+#Else
+Private Sub SendToMapButIndex(ByVal UserIndex As Integer, ByVal Buffer As clsNetWriter)
+#End If
         
         On Error GoTo SendToMapButIndex_Err
-        
-
-        '**************************************************************
-        'Author: Juan  Martín Sotuyo Dodero (Maraxus)
-        'Last Modify Date: 5/24/2007
-        '
-        '**************************************************************
         Dim LoopC     As Long
         Dim Map       As Integer
         Dim tempIndex As Integer
@@ -1192,8 +1164,11 @@ SendToMapButIndex_Err:
 
         
 End Sub
-
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToGroup(ByVal UserIndex As Integer, ByVal Buffer As Network.Writer)
+#Else
+Private Sub SendToGroup(ByVal UserIndex As Integer, ByVal Buffer As clsNetWriter)
+#End If
 On Error GoTo SendToGroup_Err
         Dim LoopC     As Long
 100     If UserIndex = 0 Then Exit Sub
@@ -1209,8 +1184,11 @@ On Error GoTo SendToGroup_Err
 SendToGroup_Err:
     Call TraceError(Err.Number, Err.Description, "modSendData.SendToGroup", Erl)
 End Sub
-
+#If DIRECT_PLAY = 0 Then
 Private Sub SendToGroupButIndex(ByVal UserIndex As Integer, ByVal Buffer As Network.Writer)
+#Else
+Private Sub SendToGroupButIndex(ByVal UserIndex As Integer, ByVal Buffer As clsNetWriter)
+#End If
 On Error GoTo SendToGroupButIndex_Err
         Dim LoopC     As Long
 100     If UserIndex = 0 Then Exit Sub


### PR DESCRIPTION
Added clsNetWriter in modSendData.

The server can now handle incoming messages from the client and replay.

Various fixes in clsNetWriter and clsNetReader: the sizes of some types was incorrect. Also DP will crash is passed a null string, I implemented a workaround for this.