### PR TITLE
Neutral NPCs. Can be attacked by everyone

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2536,6 +2536,7 @@ End Enum
 
 Public Type t_NPCFlags
 
+    AttackableByEveryone As Byte 'el NPC puede ser atacado indistintamente por PKs y Ciudadanos / ako
     AfectaParalisis As Byte
     GolpeExacto As Byte
     Domable As Integer

--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -1328,7 +1328,7 @@ Function OpenNPC(ByVal NpcNumber As Integer, _
     
 182         .flags.Domable = val(Leer.GetValue("NPC" & NpcNumber, "Domable"))
 
-            .flags.AttackableByEveryone = val(Leer.GetValue("NPC" & NpcNumber, "AttackableByEveryone")) 'makes the NPC attackable by ciudadanos and crimis
+            .flags.AttackableByEveryone = val(Leer.GetValue("NPC" & NpcNumber, "AttackableByEveryone", 0)) 'makes the NPC attackable by ciudadanos and crimis -ako
     
 184         .GiveGLD = val(Leer.GetValue("NPC" & NpcNumber, "GiveGLD"))
     
@@ -2092,27 +2092,20 @@ UserCanAttackNpc.TurnPK = False
         UserCanAttackNpc.Result = eSafeArea
         Exit Function
      End If
-     
-     If NpcList(NpcIndex).flags.AttackableByEveryone = 1 Then
-                UserCanAttackNpc.CanAttack = True
-     Else
-         ' El seguro es SOLO para ciudadanos. La armada debe desenlistarse antes de querer atacar y se checkea arriba.
-         ' Los criminales o Caos, ya estan mas alla del seguro.
-164      If Status(UserIndex) = Ciudadano Then
+        If Status(UserIndex) = Ciudadano Then
 166         If NpcList(NpcIndex).flags.Faccion = Armada Or NpcList(NpcIndex).flags.Faccion = consejo Then
 168             If UserList(UserIndex).flags.Seguro Then
 172                 UserCanAttackNpc.Result = eRemoveSafe
-                    Exit Function
+                   Exit Function
                 Else
-                    UserCanAttackNpc.Result = eAttackSameFaction
-                    UserCanAttackNpc.TurnPK = True
-                    UserCanAttackNpc.CanAttack = True
-                    Exit Function
-                 End If
-            End If
-        End If
-    End If
-    If Status(UserIndex) = Ciudadano Or Status(UserIndex) = Armada Or Status(UserIndex) = Consejo Then
+                   UserCanAttackNpc.Result = eAttackSameFaction
+                   UserCanAttackNpc.TurnPK = True
+                   UserCanAttackNpc.CanAttack = True
+                   Exit Function
+                End If
+           End If
+       End If
+    If Status(UserIndex) = Ciudadano Or Status(UserIndex) = Armada Or Status(UserIndex) = consejo Then
         'Es el NPC mascota de alguien?
 180     If IsPet Then
 182         Select Case UserList(NpcList(NpcIndex).MaestroUser.ArrayIndex).Faccion.Status
@@ -2144,30 +2137,31 @@ UserCanAttackNpc.TurnPK = False
                      Exit Function
              End Select
          End If
-         
-         If NpcList(NpcIndex).flags.team = 0 Then
-            Dim CurrentOwnerIndex As Integer: CurrentOwnerIndex = GetOwnedBy(NpcIndex)
-            If CurrentOwnerIndex <> 0 Then
-                If CurrentOwnerIndex <> UserIndex And IsValidNpcRef(UserList(CurrentOwnerIndex).flags.NPCAtacado) Then
-                    If UserList(CurrentOwnerIndex).flags.NPCAtacado.ArrayIndex = NpcIndex And _
-                        UserList(CurrentOwnerIndex).flags.Muerto = 0 And _
-                        (Status(CurrentOwnerIndex) = Ciudadano Or Status(CurrentOwnerIndex) = Armada Or Status(CurrentOwnerIndex) = consejo) And _
-                        (UserList(UserIndex).GuildIndex = 0 Or UserList(UserIndex).GuildIndex <> UserList(CurrentOwnerIndex).GuildIndex) And _
-                        (UserList(UserIndex).Grupo.EnGrupo = False Or UserList(UserIndex).Grupo.Id <> UserList(CurrentOwnerIndex).Grupo.Id) Then
-                        
-                        If UserList(UserIndex).flags.Seguro Then
-                            UserCanAttackNpc.Result = eRemoveSafeCitizenNpc
-                            Exit Function
-                        Else
-                            UserCanAttackNpc.TurnPK = True
-                            UserCanAttackNpc.CanAttack = True
-                            UserCanAttackNpc.Result = eAttackCitizenNpc
-                            Exit Function
-                        End If
-                    End If
+             If NpcList(NpcIndex).flags.AttackableByEveryone = 0 Then
+                If NpcList(NpcIndex).flags.team = 0 Then
+                   Dim CurrentOwnerIndex As Integer: CurrentOwnerIndex = GetOwnedBy(NpcIndex)
+                   If CurrentOwnerIndex <> 0 Then
+                       If CurrentOwnerIndex <> UserIndex And IsValidNpcRef(UserList(CurrentOwnerIndex).flags.NPCAtacado) Then
+                           If UserList(CurrentOwnerIndex).flags.NPCAtacado.ArrayIndex = NpcIndex And _
+                               UserList(CurrentOwnerIndex).flags.Muerto = 0 And _
+                               (Status(CurrentOwnerIndex) = Ciudadano Or Status(CurrentOwnerIndex) = Armada Or Status(CurrentOwnerIndex) = consejo) And _
+                               (UserList(UserIndex).GuildIndex = 0 Or UserList(UserIndex).GuildIndex <> UserList(CurrentOwnerIndex).GuildIndex) And _
+                               (UserList(UserIndex).Grupo.EnGrupo = False Or UserList(UserIndex).Grupo.Id <> UserList(CurrentOwnerIndex).Grupo.Id) Then
+                               
+                               If UserList(UserIndex).flags.Seguro Then
+                                   UserCanAttackNpc.Result = eRemoveSafeCitizenNpc
+                                   Exit Function
+                               Else
+                                   UserCanAttackNpc.TurnPK = True
+                                   UserCanAttackNpc.CanAttack = True
+                                   UserCanAttackNpc.Result = eAttackCitizenNpc
+                                   Exit Function
+                               End If
+                           End If
+                       End If
+                  End If
                 End If
-           End If
-        End If
+               End If
      End If
      UserCanAttackNpc.CanAttack = True
      UserCanAttackNpc.Result = eCanAttack

--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -1327,6 +1327,8 @@ Function OpenNPC(ByVal NpcNumber As Integer, _
 180         .Veneno = val(Leer.GetValue("NPC" & NpcNumber, "Veneno"))
     
 182         .flags.Domable = val(Leer.GetValue("NPC" & NpcNumber, "Domable"))
+
+            .flags.AttackableByEveryone = val(Leer.GetValue("NPC" & NpcNumber, "AttackableByEveryone")) 'makes the NPC attackable by ciudadanos and crimis
     
 184         .GiveGLD = val(Leer.GetValue("NPC" & NpcNumber, "GiveGLD"))
     
@@ -2090,19 +2092,24 @@ UserCanAttackNpc.TurnPK = False
         UserCanAttackNpc.Result = eSafeArea
         Exit Function
      End If
-     ' El seguro es SOLO para ciudadanos. La armada debe desenlistarse antes de querer atacar y se checkea arriba.
-     ' Los criminales o Caos, ya estan mas alla del seguro.
-164  If Status(UserIndex) = Ciudadano Then
-166     If NpcList(NpcIndex).flags.Faccion = Armada Or NpcList(NpcIndex).flags.Faccion = Consejo Then
-168         If UserList(UserIndex).flags.Seguro Then
-172             UserCanAttackNpc.Result = eRemoveSafe
-                Exit Function
-            Else
-                UserCanAttackNpc.Result = eAttackSameFaction
-                UserCanAttackNpc.TurnPK = True
+     
+     If NpcList(NpcIndex).flags.AttackableByEveryone = 1 Then
                 UserCanAttackNpc.CanAttack = True
-                Exit Function
-             End If
+     Else
+         ' El seguro es SOLO para ciudadanos. La armada debe desenlistarse antes de querer atacar y se checkea arriba.
+         ' Los criminales o Caos, ya estan mas alla del seguro.
+164      If Status(UserIndex) = Ciudadano Then
+166         If NpcList(NpcIndex).flags.Faccion = Armada Or NpcList(NpcIndex).flags.Faccion = consejo Then
+168             If UserList(UserIndex).flags.Seguro Then
+172                 UserCanAttackNpc.Result = eRemoveSafe
+                    Exit Function
+                Else
+                    UserCanAttackNpc.Result = eAttackSameFaction
+                    UserCanAttackNpc.TurnPK = True
+                    UserCanAttackNpc.CanAttack = True
+                    Exit Function
+                 End If
+            End If
         End If
     End If
     If Status(UserIndex) = Ciudadano Or Status(UserIndex) = Armada Or Status(UserIndex) = Consejo Then


### PR DESCRIPTION
To make an NPC attackable by everyone indistinctly (citizens can share the NPC with other citizens and also criminals) we have to add 

AttackableByEveryone=1

to the end of the NPC configuration in npcs.dat

Example (see last line):

[NPC522] 'Goblin
Name=Goblin
Head=0
Body=4116
Heading=3
Movement=2
Alineacion=0
Attackable=1
Comercia=0
Hostile=1
GiveEXP=160
MinHP=200
MaxHP=200
MaxHIT=25
MinHIT=15
DEF=0
PoderAtaque=75
PoderEvasion=40
NumQuiza=1
QuizaDropea1=1278-1
QuizaProb=10
NumDropQuest=1
DropQuest1=84-2159-1-3
Humanoide=0
NPCLVL=9
MagicResistance=23
MagicDef=0
AttackableByEveryone=1