### PR TITLE
Condicional sobre Invocación

### DIFF
--- a/Codigo/modHechizos.bas
+++ b/Codigo/modHechizos.bas
@@ -852,14 +852,6 @@ Call WriteLocaleMsg(UserIndex, "785", e_FontTypeNames.FONTTYPE_INFO)
                         If .MascotasIndex(j).ArrayIndex > 0 Then
                             If IsValidNpcRef(.MascotasIndex(j)) Then
                                 If NpcList(.MascotasIndex(j).ArrayIndex).flags.NPCActive Then
-                                    
-                                    'Si se quiere invocar un elemental de fuego, fatuo o viento, se reemplaza uno ya existente, asi solo se permite 1.
-                                    If (Hechizos(h).NumNpc = ELEMENTAL_FUEGO Or Hechizos(h).NumNpc = ELEMENTAL_VIENTO Or Hechizos(h).NumNpc = FUEGOFATUO) And _
-                                       (NpcList(.MascotasIndex(j).ArrayIndex).Numero = ELEMENTAL_FUEGO Or NpcList(.MascotasIndex(j).ArrayIndex).Numero = ELEMENTAL_VIENTO Or NpcList(.MascotasIndex(j).ArrayIndex).Numero = FUEGOFATUO) Then
-                                        Index = j
-                                        Exit For
-                                    End If
-                                
                                     If NpcList(.MascotasIndex(j).ArrayIndex).Contadores.TiempoExistencia > 0 And NpcList(.MascotasIndex(j).ArrayIndex).Contadores.TiempoExistencia < MinTiempo Then
                                         Index = j
                                         MinTiempo = NpcList(.MascotasIndex(j).ArrayIndex).Contadores.TiempoExistencia


### PR DESCRIPTION
Se elimina del código del servidor el condicional que permite 1 sola invocación de los siguientes NPCs:
- FUEGO FATUO
- ELEMENTAL DE VIENTO
- ELEMENTAL DE FUEGO

Con este cambio, se pueden invocar nuevamente hasta 3 NPCs, simulando al comportamiento del hechizo "Elemental de Agua" / "Elemental de Tierra"