### PR TITLE
DPLAY: load DPN_CAPS  from config file

### DIFF
--- a/Codigo/ServerConfig.cls
+++ b/Codigo/ServerConfig.cls
@@ -80,7 +80,17 @@ Public Function LoadSettings(ByVal Filename As String) As Long
     'Decreasing the value will have no effect. The setting is process wide, meaning it will effect your current Microsoft® DirectPlay® object and any other DirectPlay objects in your process.
     mSettings.Add "DP_NumThreads", CLng(val(reader.GetValue("DIRECTPLAY", "NumThreads", 48)))
     mSettings.Add "DP_SystemBufferSizeAs", CLng(val(reader.GetValue("DIRECTPLAY", "SystemBufferSizeAs", 65536)))
-     
+    
+    'Number of milliseconds DirectPlay should wait, since the last time it received a packet from an endpoint, before it sends a keep-alive message. You can catch the KeepAlive up to 2 times of what you specify.
+    mSettings.Add "DP_TimeoutUntilKeepAlive", CLng(val(reader.GetValue("DIRECTPLAY", "TimeoutUntilKeepAlive", 500)))
+    
+    'Number of connection retries DirectPlay should make during the connection process.
+    mSettings.Add "DP_ConnectRetries", CLng(val(reader.GetValue("DIRECTPLAY", "ConnectRetries", 20)))
+    
+    'Number of milliseconds DirectPlay should wait before it retries a connection request.
+    mSettings.Add "DP_ConnectTimeout", CLng(val(reader.GetValue("DIRECTPLAY", "ConnectTimeout", 500)))
+
+
     
 
     

--- a/Codigo/clsNetWriter.cls
+++ b/Codigo/clsNetWriter.cls
@@ -57,7 +57,7 @@ On Error GoTo send_error
     Err.Clear
     Debug.Assert lOffset > 0 ' No data in the buffer?
     ReDim Preserve oMsg(0 To lOffset - 1)
-    dps.sendto idSend, oMsg, 0, DPNSEND_GUARANTEED Or DPNSEND_PRIORITY_HIGH Or DPNSEND_NOLOOPBACK
+    dps.sendto idSend, oMsg, 0, DPNSEND_NOCOPY Or DPNSEND_PRIORITY_HIGH Or DPNSEND_NOLOOPBACK
     Exit Sub
 send_error:
     'If there is an error, handle it

--- a/Codigo/modNetwork.bas
+++ b/Codigo/modNetwork.bas
@@ -448,11 +448,13 @@ On Error GoTo listen_err
         .guidApplication = AppGuid
         .lMaxPlayers = 800
         .SessionName = "vbArgentumServer"
-        .lFlags = DPNSESSION_CLIENT_SERVER 'We must pass the client server flags if we are a server
+        .lFlags = DPNSESSION_CLIENT_SERVER Or DPNSESSION_NODPNSVR
     End With
     
     'Now set up our address value
-    dpa.SetSP dps.GetServiceProvider(1).Guid
+    Dim sp As DPN_SERVICE_PROVIDER_INFO
+    sp = dps.GetServiceProvider(1)
+    dpa.SetSP sp.Guid
     
     Dim pInfo As DPN_PLAYER_INFO
     pInfo.Name = "server"
@@ -476,6 +478,15 @@ On Error GoTo listen_err
         .lFlags = 0
     End With
     dps.SetSPCaps DP8SP_TCPIP, scaps
+    
+    Dim svr_caps As DPN_CAPS
+    svr_caps = dps.GetCaps
+    With svr_caps
+        svr_caps.lTimeoutUntilKeepAlive = SvrConfig.GetValue("DP_TimeoutUntilKeepAlive")
+        svr_caps.lConnectRetries = SvrConfig.GetValue("DP_ConnectRetries")
+        svr_caps.lConnectTimeout = SvrConfig.GetValue("DP_ConnectTimeout")
+    End With
+    dps.SetCaps svr_caps
     
     gfStarted = True
     Exit Sub

--- a/Configuracion.ini
+++ b/Configuracion.ini
@@ -3,9 +3,12 @@ BuffersPerThread=16
 DefaultEnumCount=5
 DefaultEnumRetryInterval=300
 DefaultEnumTimeout=300
-MaxEnumPayloadSize=983
-NumThreads=64
+MaxEnumPayloadSize=1024
+NumThreads=16
 SystemBufferSizeAs=65536
+TimeoutUntilKeepAlive=500
+ConnectRetries=20
+ConnectTimeout=20
 
 
 


### PR DESCRIPTION
Also disabled enumeration DPNSESSION_NODPNSVR

This lets us tune DPLAY settings with config file without having to recompile