### PR TITLE
Do not send LimitLevel in  WriteQuestDetails

### DIFF
--- a/Codigo/Protocol_Writes.bas
+++ b/Codigo/Protocol_Writes.bas
@@ -3880,7 +3880,7 @@ Public Sub WriteQuestDetails(ByVal UserIndex As Integer, _
 104     Call Writer.WriteInt16(QuestIndex)
 106     Call Writer.WriteInt8(QuestList(QuestIndex).RequiredLevel)
 108     Call Writer.WriteInt16(QuestList(QuestIndex).RequiredQuest)
-        Call Writer.WriteInt8(QuestList(QuestIndex).LimitLevel)
+    
         'Enviamos la cantidad de npcs requeridos
 110     Call Writer.WriteInt8(QuestList(QuestIndex).RequiredNPCs)
 


### PR DESCRIPTION
Elimino linea innecesaria que causaba bug visual en la ventana frmQuest del cliente