### PR TITLE
Corrección de bug en la lista de miembros del clan

### DIFF
--- a/Codigo/clsClan.cls
+++ b/Codigo/clsClan.cls
@@ -230,9 +230,8 @@ Public Function GetMemberList() As Long()
             Dim i As Integer
             For i = 0 To MemberCount - 1
                 Members(i) = MemberList(i)
-                GetMemberList = Members
-                Exit Function
             Next i
+            GetMemberList = Members
         Else
 110         GetMemberList = MemberList
         End If


### PR DESCRIPTION
Se corrigió un problema en la función GetMemberList que causaba que solo se mostrara el líder del clan después de expulsar a un miembro.

Causa del bug:
La asignación de GetMemberList = Members se realizaba dentro del bucle For, lo que provocaba una salida prematura de la función debido a un Exit Function dentro de la primera iteración.

Solución implementada:
Se movió la asignación de GetMemberList = Members fuera del bucle para garantizar que todos los miembros sean agregados correctamente antes de devolver el resultado.

Se eliminó el Exit Function dentro del bucle para permitir que el código complete la iteración correctamente.