### PR TITLE
Implementación de MinLVLDomable para npcs

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2743,7 +2743,7 @@ Public Type t_Npc
     NumQuiza As Byte
     QuizaDropea() As String
     QuizaProb As Integer
-    MinLVLDomable As Byte
+    MinTameLevel As Byte
         
     NumDestinos As Byte
     Dest() As String

--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2743,6 +2743,7 @@ Public Type t_Npc
     NumQuiza As Byte
     QuizaDropea() As String
     QuizaProb As Integer
+    MinLVLDomable As Byte
         
     NumDestinos As Byte
     Dest() As String

--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -1356,7 +1356,7 @@ Function OpenNPC(ByVal NpcNumber As Integer, _
 208         .InformarRespawn = val(Leer.GetValue("NPC" & NpcNumber, "InformarRespawn"))
     
 210         .QuizaProb = val(Leer.GetValue("NPC" & NpcNumber, "QuizaProb"))
-            .MinLVLDomable = val(Leer.GetValue("NPC" & NpcNumber, "MinLVLDomable"))
+            .MinTameLevel = val(Leer.GetValue("NPC" & NpcNumber, "MinTameLevel", 1))
         
 214         If .IntervaloMovimiento = 0 Then
 216             .IntervaloMovimiento = 380

--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -1356,6 +1356,7 @@ Function OpenNPC(ByVal NpcNumber As Integer, _
 208         .InformarRespawn = val(Leer.GetValue("NPC" & NpcNumber, "InformarRespawn"))
     
 210         .QuizaProb = val(Leer.GetValue("NPC" & NpcNumber, "QuizaProb"))
+            .MinLVLDomable = val(Leer.GetValue("NPC" & NpcNumber, "MinLVLDomable"))
         
 214         If .IntervaloMovimiento = 0 Then
 216             .IntervaloMovimiento = 380

--- a/Codigo/Trabajo.bas
+++ b/Codigo/Trabajo.bas
@@ -3428,8 +3428,9 @@ Sub DoDomar(ByVal UserIndex As Integer, ByVal NpcIndex As Integer)
                 End If
                 
                 'No tiene nivel suficiente?
-                If NpcList(NpcIndex).MinLVLDomable > .Stats.ELV Then
-                    Call SendData(SendTarget.ToIndex, UserIndex, PrepareMessageConsoleMsg("Debes ser nivel " & NpcList(NpcIndex).MinLVLDomable & " o superior para domar esta criatura.", e_FontTypeNames.FONTTYPE_INFO))
+                If NpcList(NpcIndex).MinTameLevel > .Stats.ELV Then
+                    ' Msg1321=Debes ser nivel ¬1 o superior para domar esta criatura.
+                    Call WriteLocaleMsg(UserIndex, "1321", e_FontTypeNames.FONTTYPE_INFO)
                     Exit Sub
                 End If
 

--- a/Codigo/Trabajo.bas
+++ b/Codigo/Trabajo.bas
@@ -3426,6 +3426,13 @@ Sub DoDomar(ByVal UserIndex As Integer, ByVal NpcIndex As Integer)
 120                 puntosDomar = puntosDomar / 118 'para que solo el druida dome
 
                 End If
+                
+                'No tiene nivel suficiente?
+                If NpcList(NpcIndex).MinLVLDomable > .Stats.ELV Then
+                    Call SendData(SendTarget.ToIndex, UserIndex, PrepareMessageConsoleMsg("Debes ser nivel " & NpcList(NpcIndex).MinLVLDomable & " o superior para domar esta criatura.", e_FontTypeNames.FONTTYPE_INFO))
+                    Exit Sub
+                End If
+
 
 122             If NpcList(NpcIndex).flags.Domable <= puntosDomar And RandomNumber(1, 5) = 1 Then
 


### PR DESCRIPTION
- Ahora desde el dateo se puede agregar la propiedad MinLVLDomable a los npcs. Con esta propiedad se puede definir un nivel mínimo requerido para poder domar una criatura.