### PR TITLE
Reducción de amplitud de niveles

### DIFF
--- a/Codigo/ModGrupos.bas
+++ b/Codigo/ModGrupos.bas
@@ -89,8 +89,8 @@ Public Sub InvitarMiembro(ByVal UserIndex As Integer, ByVal InvitadoIndex As Int
             
         End If
 
-130     If Abs(CInt(Invitado.Stats.ELV) - CInt(Remitente.Stats.ELV)) > 10 Then
-132         Call WriteConsoleMsg(UserIndex, "No podes crear un grupo con personajes con diferencia de más de 10 niveles.", e_FontTypeNames.FONTTYPE_New_GRUPO)
+130     If Abs(CInt(Invitado.Stats.ELV) - CInt(Remitente.Stats.ELV)) > 3 Then
+132         Call WriteConsoleMsg(UserIndex, "No podes crear un grupo con personajes con diferencia de más de 3 niveles.", e_FontTypeNames.FONTTYPE_New_GRUPO)
             Exit Sub
             
         End If


### PR DESCRIPTION
Se reduce a 3 niveles el rango el permitido para crear un grupo; de esta manera, y con un ejemplo sencillo, un personaje nivel 20 podrá armar un grupo con un compañero de nivel 23, pero no con uno de nivel 24