### PR TITLE
Fix en envios de varios mensajes

### DIFF
--- a/Codigo/ModGrupos.bas
+++ b/Codigo/ModGrupos.bas
@@ -90,9 +90,9 @@ Public Sub InvitarMiembro(ByVal UserIndex As Integer, ByVal InvitadoIndex As Int
         End If
 
 130     If Abs(CInt(Invitado.Stats.ELV) - CInt(Remitente.Stats.ELV)) > SvrConfig.GetValue("PartyELV") Then
-132         Call WriteConsoleMsg(UserIndex, "No podes crear un grupo con personajes con diferencia de más de " & SvrConfig.GetValue("PartyELV") & " niveles.", e_FontTypeNames.FONTTYPE_New_GRUPO)
+132         'Msg1438=No podes crear un grupo con personajes con diferencia de más de ¬1 niveles.
+            Call WriteLocaleMsg(UserIndex, "1438", e_FontTypeNames.FONTTYPE_New_GRUPO, SvrConfig.GetValue("PartyELV"))
             Exit Sub
-            
         End If
 
 134     If Invitado.Grupo.EnGrupo Then

--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -1864,8 +1864,8 @@ Private Sub CalcularDarExpGrupal(ByVal UserIndex As Integer, ByVal NpcIndex As I
                         Index = UserList(LiderIndex).Grupo.Miembros(i).ArrayIndex
                         ' Enviar el mensaje solo si el miembro no está muerto y tiene el chat de combate activado
                         If UserList(Index).flags.Muerto = 0 And UserList(Index).ChatCombate = 1 Then
-                            'Msg1436=El líder del grupo está demasiado lejos, su experiencia se pierde.
-                            Call WriteLocaleMsg(Index, "1436", e_FontTypeNames.FONTTYPE_EXP)
+                            'Msg1437=El líder del grupo está demasiado lejos, su experiencia se pierde.
+                            Call WriteLocaleMsg(Index, "1437", e_FontTypeNames.FONTTYPE_EXP)
                         End If
                     End If
                 Next i

--- a/Codigo/Trabajo.bas
+++ b/Codigo/Trabajo.bas
@@ -3433,7 +3433,7 @@ Sub DoDomar(ByVal UserIndex As Integer, ByVal NpcIndex As Integer)
                 'No tiene nivel suficiente?
                 If NpcList(NpcIndex).MinTameLevel > .Stats.ELV Then
                     ' Msg1321=Debes ser nivel ¬1 o superior para domar esta criatura.
-                    Call WriteLocaleMsg(UserIndex, "1321", e_FontTypeNames.FONTTYPE_INFO)
+                    Call WriteLocaleMsg(UserIndex, "1321", e_FontTypeNames.FONTTYPE_INFO, NpcList(NpcIndex).MinTameLevel)
                     Exit Sub
                 End If
 


### PR DESCRIPTION
-Cambio de id en el mensaje "El líder del grupo está demasiado lejos, su experiencia se pierde."
-Agrego id para mensaje de creación de grupo
-Arreglo el envio de mensaje "Debes ser nivel ¬1 o superior para domar esta criatura.", le faltaba el valor