### PR TITLE
Implementación de OnlyForGuilds para npcs

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2747,6 +2747,7 @@ Public Type t_Npc
     QuizaDropea() As String
     QuizaProb As Integer
     MinTameLevel As Byte
+    OnlyForGuilds As Byte
         
     NumDestinos As Byte
     Dest() As String

--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -1357,6 +1357,7 @@ Function OpenNPC(ByVal NpcNumber As Integer, _
     
 210         .QuizaProb = val(Leer.GetValue("NPC" & NpcNumber, "QuizaProb"))
             .MinTameLevel = val(Leer.GetValue("NPC" & NpcNumber, "MinTameLevel", 1))
+            .OnlyForGuilds = val(Leer.GetValue("NPC" & NpcNumber, "OnlyForGuilds", 0))
         
 214         If .IntervaloMovimiento = 0 Then
 216             .IntervaloMovimiento = 380

--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -850,6 +850,13 @@ Public Sub UsuarioAtacaNpc(ByVal UserIndex As Integer, ByVal npcIndex As Integer
         
         On Error GoTo UsuarioAtacaNpc_Err
         
+        'Si el npc es solo atacable para clanes y el usuario no tiene clan, le avisa y sale de la funcion
+        If NpcList(NpcIndex).OnlyForGuilds = 1 And UserList(UserIndex).GuildIndex <= 0 Then
+            'Msg2001=Debes pertenecer a un clan para atacar a este NPC
+            Call WriteLocaleMsg(UserIndex, "2001", e_FontTypeNames.FONTTYPE_WARNING)
+            Exit Sub
+        End If
+        
         Dim UserAttackInteractionResult As t_AttackInteractionResult
         UserAttackInteractionResult = UserCanAttackNpc(UserIndex, NpcIndex)
         Call SendAttackInteractionMessage(UserIndex, UserAttackInteractionResult.Result)

--- a/Codigo/modHechizos.bas
+++ b/Codigo/modHechizos.bas
@@ -580,6 +580,15 @@ Private Function PuedeLanzar(ByVal UserIndex As Integer, ByVal HechizoIndex As I
         
 102     With UserList(UserIndex)
 
+            'Si lanza a un npc y este es solo atacable para clanes y el usuario no tiene clan, le avisa y sale de la funcion
+            If IsValidNpcRef(.flags.TargetNPC) Then
+                If NpcList(.flags.TargetNPC.ArrayIndex).OnlyForGuilds = 1 And UserList(UserIndex).GuildIndex <= 0 Then
+                    'Msg2001=Debes pertenecer a un clan para atacar a este NPC
+                    Call WriteLocaleMsg(UserIndex, "2001", e_FontTypeNames.FONTTYPE_WARNING)
+                    Exit Function
+                End If
+            End If
+
 104         If UserList(UserIndex).flags.EnConsulta Then
 'Msg778= No puedes lanzar hechizos si estas en consulta.
 Call WriteLocaleMsg(UserIndex, "778", e_FontTypeNames.FONTTYPE_INFO)


### PR DESCRIPTION
A pedido de Temis, implemento la propiedad OnlyForGuilds para npcs.

- Con esta propiedad se puede hacer que una criatura sea atacable solo por usuarios que pertenezcan a un clan.