### PR TITLE
Update SistemaCombate.bas

### DIFF
--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -2114,7 +2114,7 @@ Private Sub UserDañoEspecial(ByVal AtacanteIndex As Integer, ByVal VictimaIndex
         End If
 
 146     If puedeParalizar And (UserList(VictimaIndex).flags.Paralizado = 0) And Not IsSet(UserList(VictimaIndex).flags.StatusMask, eCCInmunity) Then
-148         If RandomNumber(1, 100) < 10 Then
+148         If RandomNumber(1, 100) < 20 Then
 150             UserList(VictimaIndex).flags.Paralizado = 1
 152             UserList(VictimaIndex).Counters.Paralisis = 6
 


### PR DESCRIPTION
Aumenta del 10% al 20% la probabilidad de parálisis del objeto que cuente con la propiedad "EfectoMagico=11"