### PR TITLE
Added more maps to Free Potion Zone

### DIFF
--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -3239,7 +3239,7 @@ Private Function IsPotionFreeZone(ByVal UserIndex As Integer, ByVal triggerStatu
     Dim currentMap As Integer
     Dim isTriggerZone As Boolean
     Dim isTierUser As Boolean
-    Dim isTournamentZone As Boolean
+    Dim isHouseZone As Boolean
     Dim isSpecialZone As Boolean
     Dim isTrainingZone As Boolean
 
@@ -3255,16 +3255,23 @@ Private Function IsPotionFreeZone(ByVal UserIndex As Integer, ByVal triggerStatu
                   UserList(UserIndex).Stats.tipoUsuario = tLeyenda)
 
     ' Zona de casas/sotanos arenas: mapas del 600 al 749 con trigger activo
-    isTournamentZone = (currentMap >= 600 And currentMap <= 749 And isTriggerZone)
+    isHouseZone = (currentMap >= 600 And currentMap <= 749 And isTriggerZone)
 
     ' Zonas especiales fijas donde no se consumen pociones
-    isSpecialZone = (currentMap = 275 Or currentMap = 276 Or currentMap = 277 Or currentMap = 390)
+    ' 275, 276, 277 - Capture the Flag
+    ' 390, 389, 372, 324 - Arenas
+    Select Case currentMap
+        Case 275, 276, 277, 324, 372, 389, 390
+            isSpecialZone = True
+        Case Else
+            isSpecialZone = False
+    End Select
 
     ' Zona de entrenamiento: mapa 172, con trigger activo y jugador con tier
     isTrainingZone = (currentMap = 172 And isTriggerZone And isTierUser)
 
     ' Si esta en alguna de las zonas anteriores, no se consume la poción
-    IsPotionFreeZone = (isTournamentZone Or isSpecialZone Or isTrainingZone)
+    IsPotionFreeZone = (isHouseZone Or isSpecialZone Or isTrainingZone)
 End Function
 
 Sub EnivarArmasConstruibles(ByVal UserIndex As Integer)


### PR DESCRIPTION
This pull request refactors the `IsPotionFreeZone` function in `Codigo/InvUsuario.bas` to improve readability and maintainability. The changes include renaming variables for clarity and replacing a hardcoded condition with a `Select Case` statement for better extensibility.

### Refactoring for clarity and maintainability:

* Renamed the variable `isTournamentZone` to `isHouseZone` to better reflect its purpose, which checks if the current map falls within the house/basement arena range (maps 600–749 with an active trigger). [[1]](diffhunk://#diff-03be7c9b977a51a8935e8a8503f9ba726e2fe4b70b80996ad1cf4d6dbe2e50b8L3242-R3242) [[2]](diffhunk://#diff-03be7c9b977a51a8935e8a8503f9ba726e2fe4b70b80996ad1cf4d6dbe2e50b8L3258-R3274)
* Replaced the hardcoded condition for `isSpecialZone` with a `Select Case` statement, making it easier to add or modify special zones in the future. The new condition includes additional maps (324, 372, 389) for special zones.
* Updated the final condition in `IsPotionFreeZone` to use the renamed variable `isHouseZone` instead of the old `isTournamentZone`.