### PR TITLE
MapEntryPrice from byte to integer

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2529,7 +2529,7 @@ End Enum
 Public Type t_NPCFlags
 
     AttackableByEveryone As Byte 'el NPC puede ser atacado indistintamente por PKs y Ciudadanos / ako
-    MapEntryPrice As Byte
+    MapEntryPrice As Integer
     MapTargetEntry As Integer
     MapTargetEntryX As Byte
     MapTargetEntryY As Byte


### PR DESCRIPTION
As the title says, MapEntryPrice is at the moment a byte, which limits is usage to a value of 256 (in this case, maximum entry price = 256 golden coins)

We want to update this to an integer to be able to charge more for entry prices