### PR TITLE
ArenaEntry message update

### DIFF
--- a/Codigo/Protocol_GmCommands.bas
+++ b/Codigo/Protocol_GmCommands.bas
@@ -368,7 +368,7 @@ Public Sub HandleMapPriceEntrance(ByVal UserIndex As Integer)
             Call WriteLocaleMsg(UserIndex, "8", e_FontTypeNames.FONTTYPE_INFO)
 
         ElseIf .Stats.GLD < entryPrice Then
-            Call WriteLocaleChatOverHead(UserIndex, 1325, vbNullString, charIndex, vbWhite)
+            Call WriteLocaleChatOverHead(UserIndex, 2040, vbNullString, charindex, vbWhite)
             
         ElseIf NpcList(npcIndex).npcType <> e_NPCType.ArenaGuard Then
             Call WriteLocaleChatOverHead(UserIndex, 1322, vbNullString, charIndex, vbWhite)


### PR DESCRIPTION
Updates the message that is shown when the user does not have enough gold when trying to enter the arena

Now displaying message id 2040. Requested by @Temis-gt 