### PR TITLE
Added trigger validation to isArena

### DIFF
--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -3260,19 +3260,21 @@ Private Function IsPotionFreeZone(ByVal UserIndex As Integer, ByVal triggerStatu
 
     ' Zonas especiales fijas donde no se consumen pociones
     ' 275, 276, 277 - Capture the Flag
-    ' 297 - Lindo's Arena
     Select Case currentMap
-        Case 275, 276, 277, 297
+        Case 275, 276, 277
             isSpecialZone = True
         Case Else
             isSpecialZone = False
     End Select
 
+    ' 297 - Arena de Lindos
+    isArena = (currentMap = 297 And isTriggerZone And isTierUser)
+
     ' Meson Hostigado - Beneficio Patreon: mapa 172, con trigger activo y jugador con tier
     isTrainingZone = (currentMap = 172 And isTriggerZone And isTierUser)
 
     ' Si esta en alguna de las zonas anteriores, no se consume la poción
-    IsPotionFreeZone = (isHouseZone Or isSpecialZone Or isTrainingZone)
+    IsPotionFreeZone = (isHouseZone Or isSpecialZone Or isTrainingZone Or isArena)
 End Function
 
 Sub EnivarArmasConstruibles(ByVal UserIndex As Integer)


### PR DESCRIPTION
This pull request modifies the logic in the `IsPotionFreeZone` function within `Codigo/InvUsuario.bas` to refine the conditions under which potions cannot be consumed. The most important changes involve separating the handling of Lindos' Arena (`currentMap = 297`) into its own condition and updating the final potion-free zone logic accordingly.

### Changes to potion-free zone logic:

* Removed Lindos' Arena (`currentMap = 297`) from the general `isSpecialZone` condition and introduced a new variable `isArena` to handle it separately. This condition now checks for the arena map, a trigger zone, and a tiered user.
* Updated the final `IsPotionFreeZone` logic to include the new `isArena` condition alongside existing conditions (`isHouseZone`, `isSpecialZone`, and `isTrainingZone`).