### PR TITLE
Add flag to restrict object use to faction leaders only

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -1735,7 +1735,7 @@ Public Type t_ObjData
 
     Real As Integer
     Caos As Integer
-    Lider As Boolean
+    LeadersOnly As Boolean
 
     NoSeCae As Integer
     

--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -1732,10 +1732,11 @@ Public Type t_ObjData
     Snd1 As Integer
     Snd2 As Integer
     Snd3 As Integer
-    
+
     Real As Integer
     Caos As Integer
-    
+    Lider As Boolean
+
     NoSeCae As Integer
     
     Power As Integer

--- a/Codigo/FileIO.bas
+++ b/Codigo/FileIO.bas
@@ -1349,7 +1349,7 @@ Sub LoadOBJData()
 168                 Case e_OBJType.otArmadura
 170                     .Real = val(Leer.GetValue(ObjKey, "Real"))
 172                     .Caos = val(Leer.GetValue(ObjKey, "Caos"))
-173                     .Lider = val(Leer.GetValue(ObjKey, "Lider")) <> 0
+173                     .LeadersOnly = val(Leer.GetValue(ObjKey, "LeadersOnly")) <> 0
 174                     .ResistenciaMagica = val(Leer.GetValue(ObjKey, "ResistenciaMagica"))
 176                     .Invernal = val(Leer.GetValue(ObjKey, "Invernal")) > 0
         
@@ -1357,7 +1357,7 @@ Sub LoadOBJData()
 180                     .ShieldAnim = val(Leer.GetValue(ObjKey, "Anim"))
 182                     .Real = val(Leer.GetValue(ObjKey, "Real"))
 184                     .Caos = val(Leer.GetValue(ObjKey, "Caos"))
-185                     .Lider = val(Leer.GetValue(ObjKey, "Lider")) <> 0
+185                     .LeadersOnly = val(Leer.GetValue(ObjKey, "LeadersOnly")) <> 0
 186                     .ResistenciaMagica = val(Leer.GetValue(ObjKey, "ResistenciaMagica"))
                         .Porcentaje = val(Leer.GetValue(ObjKey, "Porcentaje"))
         
@@ -1365,7 +1365,7 @@ Sub LoadOBJData()
 190                     .CascoAnim = val(Leer.GetValue(ObjKey, "Anim"))
 192                     .Real = val(Leer.GetValue(ObjKey, "Real"))
 194                     .Caos = val(Leer.GetValue(ObjKey, "Caos"))
-195                     .Lider = val(Leer.GetValue(ObjKey, "Lider")) <> 0
+195                     .LeadersOnly = val(Leer.GetValue(ObjKey, "LeadersOnly")) <> 0
 196                     .ResistenciaMagica = val(Leer.GetValue(ObjKey, "ResistenciaMagica"))
         
 198                 Case e_OBJType.otWeapon
@@ -1386,7 +1386,7 @@ Sub LoadOBJData()
 220                     .Power = val(Leer.GetValue(ObjKey, "StaffPower"))
 226                     .Real = val(Leer.GetValue(ObjKey, "Real"))
 228                     .Caos = val(Leer.GetValue(ObjKey, "Caos"))
-229                     .Lider = val(Leer.GetValue(ObjKey, "Lider")) <> 0
+229                     .LeadersOnly = val(Leer.GetValue(ObjKey, "LeadersOnly")) <> 0
 230                     .EfectoMagico = val(Leer.GetValue(ObjKey, "efectomagico"))
 232                     .Revive = val(Leer.GetValue(ObjKey, "Revive")) <> 0
 234                     .DosManos = val(Leer.GetValue(ObjKey, "DosManos"))
@@ -1398,7 +1398,7 @@ Sub LoadOBJData()
                         'Pablo (ToxicWaste)
 238                     .Real = val(Leer.GetValue(ObjKey, "Real"))
 240                     .Caos = val(Leer.GetValue(ObjKey, "Caos"))
-241                     .Lider = val(Leer.GetValue(ObjKey, "Lider")) <> 0
+241                     .LeadersOnly = val(Leer.GetValue(ObjKey, "LeadersOnly")) <> 0
         
 242                 Case e_OBJType.otPuertas, e_OBJType.otBotellaVacia, e_OBJType.otBotellaLlena
 244                     .IndexAbierta = val(Leer.GetValue(ObjKey, "IndexAbierta"))
@@ -1447,7 +1447,7 @@ Sub LoadOBJData()
 282                     .MaxDef = val(Leer.GetValue(ObjKey, "MAXDEF"))
 284                     .Real = val(Leer.GetValue(ObjKey, "Real"))
 286                     .Caos = val(Leer.GetValue(ObjKey, "Caos"))
-287                     .Lider = val(Leer.GetValue(ObjKey, "Lider")) <> 0
+287                     .LeadersOnly = val(Leer.GetValue(ObjKey, "LeadersOnly")) <> 0
 288                     .velocidad = val(Leer.GetValue(ObjKey, "Velocidad"))
         
 290                 Case e_OBJType.otFlechas

--- a/Codigo/FileIO.bas
+++ b/Codigo/FileIO.bas
@@ -1349,6 +1349,7 @@ Sub LoadOBJData()
 168                 Case e_OBJType.otArmadura
 170                     .Real = val(Leer.GetValue(ObjKey, "Real"))
 172                     .Caos = val(Leer.GetValue(ObjKey, "Caos"))
+173                     .Lider = val(Leer.GetValue(ObjKey, "Lider")) <> 0
 174                     .ResistenciaMagica = val(Leer.GetValue(ObjKey, "ResistenciaMagica"))
 176                     .Invernal = val(Leer.GetValue(ObjKey, "Invernal")) > 0
         
@@ -1356,6 +1357,7 @@ Sub LoadOBJData()
 180                     .ShieldAnim = val(Leer.GetValue(ObjKey, "Anim"))
 182                     .Real = val(Leer.GetValue(ObjKey, "Real"))
 184                     .Caos = val(Leer.GetValue(ObjKey, "Caos"))
+185                     .Lider = val(Leer.GetValue(ObjKey, "Lider")) <> 0
 186                     .ResistenciaMagica = val(Leer.GetValue(ObjKey, "ResistenciaMagica"))
                         .Porcentaje = val(Leer.GetValue(ObjKey, "Porcentaje"))
         
@@ -1363,6 +1365,7 @@ Sub LoadOBJData()
 190                     .CascoAnim = val(Leer.GetValue(ObjKey, "Anim"))
 192                     .Real = val(Leer.GetValue(ObjKey, "Real"))
 194                     .Caos = val(Leer.GetValue(ObjKey, "Caos"))
+195                     .Lider = val(Leer.GetValue(ObjKey, "Lider")) <> 0
 196                     .ResistenciaMagica = val(Leer.GetValue(ObjKey, "ResistenciaMagica"))
         
 198                 Case e_OBJType.otWeapon
@@ -1383,6 +1386,7 @@ Sub LoadOBJData()
 220                     .Power = val(Leer.GetValue(ObjKey, "StaffPower"))
 226                     .Real = val(Leer.GetValue(ObjKey, "Real"))
 228                     .Caos = val(Leer.GetValue(ObjKey, "Caos"))
+229                     .Lider = val(Leer.GetValue(ObjKey, "Lider")) <> 0
 230                     .EfectoMagico = val(Leer.GetValue(ObjKey, "efectomagico"))
 232                     .Revive = val(Leer.GetValue(ObjKey, "Revive")) <> 0
 234                     .DosManos = val(Leer.GetValue(ObjKey, "DosManos"))
@@ -1394,6 +1398,7 @@ Sub LoadOBJData()
                         'Pablo (ToxicWaste)
 238                     .Real = val(Leer.GetValue(ObjKey, "Real"))
 240                     .Caos = val(Leer.GetValue(ObjKey, "Caos"))
+241                     .Lider = val(Leer.GetValue(ObjKey, "Lider")) <> 0
         
 242                 Case e_OBJType.otPuertas, e_OBJType.otBotellaVacia, e_OBJType.otBotellaLlena
 244                     .IndexAbierta = val(Leer.GetValue(ObjKey, "IndexAbierta"))
@@ -1442,6 +1447,7 @@ Sub LoadOBJData()
 282                     .MaxDef = val(Leer.GetValue(ObjKey, "MAXDEF"))
 284                     .Real = val(Leer.GetValue(ObjKey, "Real"))
 286                     .Caos = val(Leer.GetValue(ObjKey, "Caos"))
+287                     .Lider = val(Leer.GetValue(ObjKey, "Lider")) <> 0
 288                     .velocidad = val(Leer.GetValue(ObjKey, "Velocidad"))
         
 290                 Case e_OBJType.otFlechas

--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -1059,15 +1059,18 @@ Function FaccionPuedeUsarItem(ByVal UserIndex As Integer, ByVal ObjIndex As Inte
 104     If ObjIndex < 1 Then Exit Function
 
 106     If ObjData(ObjIndex).Real = 1 Then
-108         If Status(UserIndex) = e_Facciones.Armada Or Status(UserIndex) = e_Facciones.consejo Then
+107         If ObjData(ObjIndex).Lider Then
+108             FaccionPuedeUsarItem = (Status(UserIndex) = e_Facciones.consejo)
+109         ElseIf Status(UserIndex) = e_Facciones.Armada Or Status(UserIndex) = e_Facciones.consejo Then
 110             FaccionPuedeUsarItem = esArmada(UserIndex)
             Else
 112             FaccionPuedeUsarItem = False
             End If
 
 114     ElseIf ObjData(ObjIndex).Caos = 1 Then
-
-116         If Status(UserIndex) = e_Facciones.Caos Or Status(UserIndex) = e_Facciones.concilio Then
+115         If ObjData(ObjIndex).Lider Then
+116             FaccionPuedeUsarItem = (Status(UserIndex) = e_Facciones.concilio)
+117         ElseIf Status(UserIndex) = e_Facciones.Caos Or Status(UserIndex) = e_Facciones.concilio Then
 118             FaccionPuedeUsarItem = esCaos(UserIndex)
             Else
 120             FaccionPuedeUsarItem = False
@@ -3235,7 +3238,7 @@ End Sub
 '
 ' Returns:     Boolean - True if the user is in a potion-free zone
 '                       False if the potion should be consumed
-'************************************************************** 
+'**************************************************************
 Private Function IsPotionFreeZone(ByVal UserIndex As Integer, ByVal triggerStatus As e_Trigger6) As Boolean
     Dim currentMap As Integer
     Dim isTriggerZone As Boolean

--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -1059,7 +1059,7 @@ Function FaccionPuedeUsarItem(ByVal UserIndex As Integer, ByVal ObjIndex As Inte
 104     If ObjIndex < 1 Then Exit Function
 
 106     If ObjData(ObjIndex).Real = 1 Then
-107         If ObjData(ObjIndex).Lider Then
+107         If ObjData(ObjIndex).LeadersOnly Then
 108             FaccionPuedeUsarItem = (Status(UserIndex) = e_Facciones.consejo)
 109         ElseIf Status(UserIndex) = e_Facciones.Armada Or Status(UserIndex) = e_Facciones.consejo Then
 110             FaccionPuedeUsarItem = esArmada(UserIndex)
@@ -1068,7 +1068,7 @@ Function FaccionPuedeUsarItem(ByVal UserIndex As Integer, ByVal ObjIndex As Inte
             End If
 
 114     ElseIf ObjData(ObjIndex).Caos = 1 Then
-115         If ObjData(ObjIndex).Lider Then
+115         If ObjData(ObjIndex).LeadersOnly Then
 116             FaccionPuedeUsarItem = (Status(UserIndex) = e_Facciones.concilio)
 117         ElseIf Status(UserIndex) = e_Facciones.Caos Or Status(UserIndex) = e_Facciones.concilio Then
 118             FaccionPuedeUsarItem = esCaos(UserIndex)


### PR DESCRIPTION
Flag name "LeadersOnly". Values 0 or 1.
It's meant to be used with flags "Real" or "Caos".