### PR TITLE
cambio de probabilidad de rechazo c escudo

### DIFF
--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -1075,7 +1075,7 @@ Private Function UsuarioImpacto(ByVal AtacanteIndex As Integer, ByVal VictimaInd
         Dim SkillTacticas          As Long
         Dim SkillDefensa           As Long
         Dim ProbEvadir             As Long
-        Dim ShieldChancePercentaje As Long
+        Dim ShieldChancePercentage As Long
 
 100     If UserList(AtacanteIndex).flags.GolpeCertero = 1 Then
 102         UsuarioImpacto = True
@@ -1105,11 +1105,11 @@ Private Function UsuarioImpacto(ByVal AtacanteIndex As Integer, ByVal VictimaInd
 126     UserPoderEvasion = PoderEvasion(VictimaIndex)
 
 128     If UserList(VictimaIndex).Invent.EscudoEqpObjIndex > 0 Then
-            ShieldChancePercentaje = ObjData(UserList(VictimaIndex).invent.EscudoEqpObjIndex).Porcentaje
-            If ShieldChancePercentaje > 0 Then
+            ShieldChancePercentage = ObjData(UserList(VictimaIndex).invent.EscudoEqpObjIndex).Porcentaje
+            If ShieldChancePercentage > 0 Then
 130         UserPoderEvasion = UserPoderEvasion + PoderEvasionEscudo(VictimaIndex)
 132         If SkillDefensa > 0 Then
-134             ProbRechazo = Maximo(10, Minimo(90, (ShieldChancePercentaje * (SkillDefensa / (Maximo(SkillDefensa + SkillTacticas, 1))))))
+134             ProbRechazo = Maximo(10, Minimo(90, (ShieldChancePercentage * (SkillDefensa / (Maximo(SkillDefensa + SkillTacticas, 1))))))
             Else
 136             ProbRechazo = 10
             End If

--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -1075,7 +1075,7 @@ Private Function UsuarioImpacto(ByVal AtacanteIndex As Integer, ByVal VictimaInd
         Dim SkillTacticas          As Long
         Dim SkillDefensa           As Long
         Dim ProbEvadir             As Long
-        Dim PorcentajeRechazoEsc   As Long
+        Dim ShieldChancePercentaje As Long
 
 100     If UserList(AtacanteIndex).flags.GolpeCertero = 1 Then
 102         UsuarioImpacto = True
@@ -1105,11 +1105,11 @@ Private Function UsuarioImpacto(ByVal AtacanteIndex As Integer, ByVal VictimaInd
 126     UserPoderEvasion = PoderEvasion(VictimaIndex)
 
 128     If UserList(VictimaIndex).Invent.EscudoEqpObjIndex > 0 Then
-            PorcentajeRechazoEsc = ObjData(UserList(VictimaIndex).invent.EscudoEqpObjIndex).Porcentaje
-            If PorcentajeRechazoEsc > 0 Then
+            ShieldChancePercentaje = ObjData(UserList(VictimaIndex).invent.EscudoEqpObjIndex).Porcentaje
+            If ShieldChancePercentaje > 0 Then
 130         UserPoderEvasion = UserPoderEvasion + PoderEvasionEscudo(VictimaIndex)
 132         If SkillDefensa > 0 Then
-134             ProbRechazo = Maximo(10, Minimo(90, (PorcentajeRechazoEsc * (SkillDefensa / (Maximo(SkillDefensa + SkillTacticas, 1))))))
+134             ProbRechazo = Maximo(10, Minimo(90, (ShieldChancePercentaje * (SkillDefensa / (Maximo(SkillDefensa + SkillTacticas, 1))))))
             Else
 136             ProbRechazo = 10
             End If

--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -1075,6 +1075,7 @@ Private Function UsuarioImpacto(ByVal AtacanteIndex As Integer, ByVal VictimaInd
         Dim SkillTacticas          As Long
         Dim SkillDefensa           As Long
         Dim ProbEvadir             As Long
+        Dim PorcentajeRechazoEsc   As Long
 
 100     If UserList(AtacanteIndex).flags.GolpeCertero = 1 Then
 102         UsuarioImpacto = True
@@ -1104,10 +1105,11 @@ Private Function UsuarioImpacto(ByVal AtacanteIndex As Integer, ByVal VictimaInd
 126     UserPoderEvasion = PoderEvasion(VictimaIndex)
 
 128     If UserList(VictimaIndex).Invent.EscudoEqpObjIndex > 0 Then
-          If ObjData(UserList(VictimaIndex).Invent.EscudoEqpObjIndex).Porcentaje > 0 Then
+        PorcentajeRechazoEsc = ObjData(UserList(VictimaIndex).invent.EscudoEqpObjIndex).Porcentaje
+          If PorcentajeRechazoEsc > 0 Then
 130         UserPoderEvasion = UserPoderEvasion + PoderEvasionEscudo(VictimaIndex)
 132         If SkillDefensa > 0 Then
-134             ProbRechazo = Maximo(10, Minimo(90, 100 * (SkillDefensa / (Maximo(SkillDefensa + SkillTacticas, 1)))))
+134             ProbRechazo = Maximo(10, Minimo(90, (PorcentajeRechazoEsc * (SkillDefensa / (Maximo(SkillDefensa + SkillTacticas, 1))))))
             Else
 136             ProbRechazo = 10
             End If

--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -1105,8 +1105,8 @@ Private Function UsuarioImpacto(ByVal AtacanteIndex As Integer, ByVal VictimaInd
 126     UserPoderEvasion = PoderEvasion(VictimaIndex)
 
 128     If UserList(VictimaIndex).Invent.EscudoEqpObjIndex > 0 Then
-        PorcentajeRechazoEsc = ObjData(UserList(VictimaIndex).invent.EscudoEqpObjIndex).Porcentaje
-          If PorcentajeRechazoEsc > 0 Then
+            PorcentajeRechazoEsc = ObjData(UserList(VictimaIndex).invent.EscudoEqpObjIndex).Porcentaje
+            If PorcentajeRechazoEsc > 0 Then
 130         UserPoderEvasion = UserPoderEvasion + PoderEvasionEscudo(VictimaIndex)
 132         If SkillDefensa > 0 Then
 134             ProbRechazo = Maximo(10, Minimo(90, (PorcentajeRechazoEsc * (SkillDefensa / (Maximo(SkillDefensa + SkillTacticas, 1))))))


### PR DESCRIPTION
-ahora la probabilidad de rechazo con escudo utiliza la propiedad porcentaje, que antiguamente solo servia para denotar un escudo "cosmetico" de uno funcional

-teniendo dicha propiedad porcentaje=100 los escudos actuan de manera normal, teniendo un numero menor a 100 y mayor a 1 reducen su porcentaje de efectividad de escudeo 1 a 1 de manera porcentual, es decir que si porcentaje = 95, el esucdo escuda un 5% menos de lo normal

-se mantiene aun asi la funcionalidad de dejar la propiedad = 0 para escudos cosmeticos