### PR TITLE
Add validation for unassisted macro usage using SPELL_UNASSISTED_FULGOR

### DIFF
--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -32,6 +32,8 @@ Option Explicit
 'having too many string lengths in the queue. Yes, each string is NULL-terminated :P
 Public Const SEPARATOR             As String * 1 = vbNullChar
 
+Private Const SPELL_UNASSISTED_FULGOR = 52
+
 Public Enum e_EditOptions
 
     eo_Gold = 1
@@ -9742,7 +9744,7 @@ Private Sub HandleLogMacroClickHechizo(ByVal UserIndex As Integer)
                     mensaje = mensaje & UserList(UserIndex).name & "| está utilizando macro de DOBLE CLICK (CANTIDAD DE CLICKS: " & clicks & " )."
                     Call SendData(SendTarget.ToAdminsYDioses, 0, PrepareMessageConsoleMsg(mensaje, e_FontTypeNames.FONTTYPE_INFO))
                 Case tMacro.inasistidoPosFija
-                    If Not (UserList(UserIndex).Stats.UserHechizos(.flags.Hechizo)) = 52 Then
+                    If Not (UserList(UserIndex).Stats.UserHechizos(.flags.Hechizo)) = SPELL_UNASSISTED_FULGOR Then
                         mensaje = mensaje & UserList(UserIndex).name & "| está utilizando macro de INASISTIDO."
                         Call SendData(SendTarget.ToAdminsYDioses, 0, PrepareMessageConsoleMsg(mensaje, e_FontTypeNames.FONTTYPE_INFO))
                     End If


### PR DESCRIPTION
Add validation for unassisted macro usage using SPELL_UNASSISTED_FULGOR

- Replaced hardcoded spell ID (52) with named constant SPELL_UNASSISTED_FULGOR
- Prepared condition for future support of additional unassisted spell IDs
- Improved readability and maintainability by avoiding magic numbers
- This change ensures that only defined spells can trigger the unassisted macro behavior

Closes issue #XXX (if applicable)