### PR TITLE
Cambio en el tiempo de cárcel permitido

### DIFF
--- a/Codigo/Protocol_GmCommands.bas
+++ b/Codigo/Protocol_GmCommands.bas
@@ -1174,13 +1174,13 @@ Public Sub HandleJail(ByVal UserIndex As Integer)
         
             Dim username As String
             Dim Reason   As String
-            Dim jailTime As Byte
+            Dim jailTime As Integer
             Dim count    As Byte
             Dim tUser    As t_UserReference
         
 102         username = Reader.ReadString8()
 104         Reason = Reader.ReadString8()
-106         jailTime = Reader.ReadInt8()
+106         jailTime = reader.ReadInt16()
         
 108         If InStr(1, username, "+") Then
 110             username = Replace(username, "+", " ")
@@ -1205,9 +1205,9 @@ Public Sub HandleJail(ByVal UserIndex As Integer)
                             'Msg957= No podés encarcelar a administradores.
                             Call WriteLocaleMsg(UserIndex, "957", e_FontTypeNames.FONTTYPE_INFO)
                     
-128                     ElseIf jailTime > 240 Then
-                            'Msg958= No podés encarcelar por más de 4 horas.
-                            Call WriteLocaleMsg(UserIndex, "958", e_FontTypeNames.FONTTYPE_INFO)
+128                     ElseIf jailTime > SvrConfig.GetValue("MaxJailTime") Then
+                            'Msg958= No podés encarcelar por más de ¬1 minutos.
+                            Call WriteLocaleMsg(UserIndex, "958", e_FontTypeNames.FONTTYPE_INFO, SvrConfig.GetValue("MaxJailTime"))
                         Else
 
 132                         If (InStrB(username, "\") <> 0) Then

--- a/Codigo/ServerConfig.cls
+++ b/Codigo/ServerConfig.cls
@@ -105,6 +105,7 @@ Public Function LoadSettings(ByVal Filename As String) As Long
     mSettings.Add "PartyELV", CInt(val(Reader.GetValue("CONFIGURACIONES", "PartyELV", "4")))
     mSettings.Add "PenaltyExpUserPerLevel", CSng(val(reader.GetValue("CONFIGURACIONES", "PenaltyExpUserPerLevel", "0.05")))
     mSettings.Add "DeltaLevelExpPenalty", CInt(val(Reader.GetValue("CONFIGURACIONES", "DeltaLevelExpPenalty", "4")))
+    mSettings.Add "MaxJailTime", CInt(val(reader.GetValue("CONFIGURACIONES", "MaxJailTime", "8640")))
     
     mSettings.Add "DropMult", CInt(val(reader.GetValue("DROPEO", "DropMult")))
     mSettings.Add "DropActive", CInt(val(reader.GetValue("DROPEO", "DropActive")))

--- a/Configuracion.ini
+++ b/Configuracion.ini
@@ -30,6 +30,7 @@ ChatGlobal=0
 PartyELV=4
 PenaltyExpUserPerLevel=0.05
 DeltaLevelExpPenalty=4
+MaxJailTime=8640
 
 'Mientras mas alto sea DropMult menos probabilidad de tirar algun item.
 [DROPEO]


### PR DESCRIPTION
Este cambio permite encarcelar a los usuarios por más tiempo. 
Antes: 240 minutos.
Ahora: 8640 minutos.