### PR TITLE
Limit trainer pets to 5 and update message handling

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -368,7 +368,7 @@ Public Const FireEcoIndex            As String = "Eco Ígneo (NPC)"
 Public Const MauveFlashIndex         As String = "Destello Malva (NPC)"
 
 
-Public Const MAXMASCOTASENTRENADOR   As Byte = 7
+Public Const MAXMASCOTASENTRENADOR   As Byte = 5
 
 Public Enum e_FXSound
 


### PR DESCRIPTION
Reduced MAXMASCOTASENTRENADOR from 7 to 5 in Declares.bas. Updated Protocol.bas to use localized message (2082) when the pet limit is reached, replacing the previous hardcoded chat message.