### PR TITLE
feat(server): track server uptime and show on user login

### DIFF
--- a/Codigo/General.bas
+++ b/Codigo/General.bas
@@ -537,6 +537,8 @@ End Sub
 
 Sub Main()
 On Error GoTo Handler
+        Call Uptime_Init
+        
 #If DIRECT_PLAY = 1 Then
         InitDPlay
 #End If

--- a/Codigo/TCP.bas
+++ b/Codigo/TCP.bas
@@ -1031,24 +1031,27 @@ ErrHandler:
 
 End Function
 
-Sub SendMOTD(ByVal UserIndex As Integer)
-        
-        On Error GoTo SendMOTD_Err
-        
-
-        Dim j As Long
-
-100     For j = 1 To MaxLines
-102         Call WriteConsoleMsg(UserIndex, MOTD(j).texto, e_FontTypeNames.FONTTYPE_EXP)
-104     Next j
+Private Sub SendWelcomeUptime(ByVal UserIndex As Integer)
+    Dim msg As String
+    msg = "Server Uptime: " & FormatUptime()
     
-        
+    ' Pick the font/type you prefer. Examples used in this codebase include FONTTYPE_INFO or FONTTYPE_GUILD.
+    ' If your helper uses a different enum or function name, keep the same idea:
+    '   SendData(ToUser, UserIndex, PrepareMessageConsoleMsg(msg, e_FontTypeNames.FONTTYPE_INFO))
+    Call SendData(SendTarget.ToIndex, UserIndex, PrepareMessageConsoleMsg(msg, e_FontTypeNames.FONTTYPE_INFO))
+End Sub
+
+
+Sub SendMOTD(ByVal UserIndex As Integer)
+  On Error GoTo SendMOTD_Err
+        Dim j As Long
+        For j = 1 To MaxLines
+            Call WriteConsoleMsg(UserIndex, MOTD(j).texto, e_FontTypeNames.FONTTYPE_EXP)
+        Next j
+        Call SendWelcomeUptime(UserIndex)
         Exit Sub
-
 SendMOTD_Err:
-106     Call TraceError(Err.Number, Err.Description, "TCP.SendMOTD", Erl)
-
-        
+     Call TraceError(Err.Number, Err.Description, "TCP.SendMOTD", Erl)
 End Sub
 
 Sub ResetFacciones(ByVal UserIndex As Integer)

--- a/Codigo/modUptime.bas
+++ b/Codigo/modUptime.bas
@@ -1,0 +1,54 @@
+Attribute VB_Name = "modUptime"
+' Argentum 20 Game Server
+'
+'    Copyright (C) 2025 Noland Studios LTD
+'
+'    This program is free software: you can redistribute it and/or modify
+'    it under the terms of the GNU Affero General Public License as published by
+'    the Free Software Foundation, either version 3 of the License, or
+'    (at your option) any later version.
+'
+'    This program is distributed in the hope that it will be useful,
+'    but WITHOUT ANY WARRANTY; without even the implied warranty of
+'    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+'    GNU Affero General Public License for more details.
+'
+'    You should have received a copy of the GNU Affero General Public License
+'    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+'
+'    This program was based on Argentum Online 0.11.6
+'    Copyright (C) 2002 Márquez Pablo Ignacio
+'
+'    Argentum Online is based on Baronsoft's VB6 Online RPG
+'    You can contact the original creator of ORE at aaron@baronsoft.com
+'    for more information about ORE please visit http://www.baronsoft.com/
+'
+'
+'
+'
+Option Explicit
+
+' When the process starts, we save the current time.
+Public g_ServerStart As Date
+
+Public Sub Uptime_Init()
+    g_ServerStart = Now
+End Sub
+
+' Total seconds since start (safe for many years).
+Public Function GetServerUptimeSeconds() As Long
+    GetServerUptimeSeconds = DateDiff("s", g_ServerStart, Now)
+End Function
+
+' Human-friendly formatting: 3d 12:34:56
+Public Function FormatUptime() As String
+    Dim total As Long, d As Long, h As Long, m As Long, s As Long
+    
+    total = GetServerUptimeSeconds()
+    d = total \ 86400: total = total Mod 86400
+    h = total \ 3600: total = total Mod 3600
+    m = total \ 60:   s = total Mod 60
+    
+    FormatUptime = CStr(d) & "d " & Right$("0" & h, 2) & ":" & Right$("0" & m, 2) & ":" & Right$("0" & s, 2)
+End Function
+

--- a/Server.VBP
+++ b/Server.VBP
@@ -130,6 +130,7 @@ Class=clsNetReader; Codigo\clsNetReader.cls
 Class=clsNetWriter; Codigo\clsNetWriter.cls
 Module=StringUtils; Codigo\StringUtils.bas
 Module=Consts; Codigo\Consts.bas
+Module=modUptime; Codigo\modUptime.bas
 IconForm="frmMain"
 Startup="Sub Main"
 HelpFile=""


### PR DESCRIPTION
- Added new module `modUptime` to record server start time and calculate formatted uptime (days, hours, minutes, seconds).
- Initialized uptime tracking at server startup.
- On successful user login, server now sends a welcome message with the current uptime using `FONTTYPE_INFO`.

This allows players to see how long the server has been running continuously since last start