### PR TITLE
fix_HunterStaysHidden

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -1916,10 +1916,9 @@ Public Type t_ObjData
     WeaponType As e_WeaponType
     ProjectileType As Integer
     ObjFlags As Long 'use bitmask from enum e_ObjFlags
-    
     JineteLevel As Byte
     ElementalTags As Long
-    
+    Camouflage As Byte
 End Type
 
 '[Pablo ToxicWaste]

--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -1918,7 +1918,7 @@ Public Type t_ObjData
     ObjFlags As Long 'use bitmask from enum e_ObjFlags
     JineteLevel As Byte
     ElementalTags As Long
-    Camouflage As Byte
+    Camouflage As Boolean
 End Type
 
 '[Pablo ToxicWaste]

--- a/Codigo/FileIO.bas
+++ b/Codigo/FileIO.bas
@@ -1411,7 +1411,7 @@ Sub LoadOBJData()
 173                     .LeadersOnly = val(Leer.GetValue(ObjKey, "LeadersOnly")) <> 0
 174                     .ResistenciaMagica = val(Leer.GetValue(ObjKey, "ResistenciaMagica"))
 176                     .Invernal = val(Leer.GetValue(ObjKey, "Invernal")) > 0
-                        .Camouflage = val(Leer.GetValue(ObjKey, "Camouflage"))
+                        .Camouflage = val(Leer.GetValue(ObjKey, "Camouflage")) > 0
         
 178                 Case e_OBJType.otShield
 180                     .ShieldAnim = val(Leer.GetValue(ObjKey, "Anim"))

--- a/Codigo/FileIO.bas
+++ b/Codigo/FileIO.bas
@@ -1411,6 +1411,7 @@ Sub LoadOBJData()
 173                     .LeadersOnly = val(Leer.GetValue(ObjKey, "LeadersOnly")) <> 0
 174                     .ResistenciaMagica = val(Leer.GetValue(ObjKey, "ResistenciaMagica"))
 176                     .Invernal = val(Leer.GetValue(ObjKey, "Invernal")) > 0
+                        .Camouflage = val(Leer.GetValue(ObjKey, "Camouflage"))
         
 178                 Case e_OBJType.otShield
 180                     .ShieldAnim = val(Leer.GetValue(ObjKey, "Anim"))

--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -1196,22 +1196,45 @@ Public Sub UsuarioAtacaUsuario(ByVal AtacanteIndex As Integer, ByVal VictimaInde
                 UserList(VictimaIndex).Counters.timeFx = 3
 114             Call SendData(SendTarget.ToPCAliveArea, VictimaIndex, PrepareMessageCreateFX(UserList(VictimaIndex).Char.charindex, FXSANGRE, 0, UserList(VictimaIndex).Pos.X, UserList(VictimaIndex).Pos.y))
             End If
-            
-            Call RemoveUserInvisibility(AtacanteIndex)
+
+            Select Case UserList(AtacanteIndex).clase
+                Case e_Class.Hunter
+                    'if i have an armor equipped
+                    if UserList(AtacanteIndex).invent.EquippedArmorObjIndex > 0 Then
+                        'and the armor has the camouflage property and i have 100 in stealth skill
+                        if ObjData(UserList(AtacanteIndex).invent.EquippedArmorObjIndex).Camouflage And UserList(AtacanteIndex).Stats.UserSkills(e_Skill.Ocultarse) = 100 Then
+                            'dont remove invisibility
+                        Else
+                            Call RemoveUserInvisibility(AtacanteIndex)
+                        End If
+                    end if
+                Case Else
+                    Call RemoveUserInvisibility(AtacanteIndex)
+            End Select
+
 116         Call UserDamageToUser(AtacanteIndex, VictimaIndex, aType)
             Call EffectsOverTime.TartgetDidHit(UserList(AtacanteIndex).EffectOverTime, VictimaIndex, eUser, e_phisical)
             Call RegisterNewAttack(VictimaIndex, AtacanteIndex)
 
-
         Else
-
-            If UserList(AtacanteIndex).clase <> e_Class.Bandit Then
-                Call RemoveUserInvisibility(AtacanteIndex)
-            Else
-                If Not UserList(AtacanteIndex).Stats.UserSkills(e_Skill.Ocultarse) = 100 Then
+            Select Case UserList(AtacanteIndex).clase
+                Case e_Class.Bandit
+                    If Not UserList(AtacanteIndex).Stats.UserSkills(e_Skill.Ocultarse) = 100 Then
+                        Call RemoveUserInvisibility(AtacanteIndex)
+                    End If
+                Case e_Class.Hunter
+                    'if i have an armor equipped
+                    if UserList(AtacanteIndex).invent.EquippedArmorObjIndex > 0 Then
+                        'and the armor has the camouflage property and i have 100 in stealth skill
+                        if ObjData(UserList(AtacanteIndex).invent.EquippedArmorObjIndex).Camouflage And UserList(AtacanteIndex).Stats.UserSkills(e_Skill.Ocultarse) = 100 Then
+                            'dont remove invisibility
+                        Else
+                            Call RemoveUserInvisibility(AtacanteIndex)
+                        End If
+                    end if
+                Case Else
                     Call RemoveUserInvisibility(AtacanteIndex)
-                End If
-            End If
+            End Select
 
             Call EffectsOverTime.TargetFailedAttack(UserList(AtacanteIndex).EffectOverTime, VictimaIndex, eUser, e_phisical)
 118         If UserList(AtacanteIndex).flags.invisible Or UserList(AtacanteIndex).flags.Oculto Then


### PR DESCRIPTION
-fixed a bug after https://github.com/ao-org/argentum-online-server/commit/60f8bac521a342ff09b43230a412e81d0df31307 that denied the hunter to stay hidden after missing or connecting an attack
-decoupled hardcoded "hunter armor id" for a generic Camouflage boolean property
-in order to get this bonus, the hunter must be hidden, have 100 in "hide" skill and have an armour that has the camouflage property
-also byte ordered the t_ObjData structure to have more performance