### PR TITLE
Codex/add support for no drop maps functionality

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -269,6 +269,8 @@ Public MapasInterdimensionales() As Integer
 
 Public MapasEventos() As Integer
 
+Public MapasNoDrop() As Integer
+
 Public Enum e_Minerales
     Coal = 3391
     HierroCrudo = 192

--- a/Codigo/FileIO.bas
+++ b/Codigo/FileIO.bas
@@ -1964,7 +1964,7 @@ Sub LoadMapData()
 
         If RunningInVB() Then
                 'VB runs out of memory when debugging
-                NumMaps = 300
+                NumMaps = 600
         Else
                 NumMaps = CountFiles(MapPath, "*.csm") - 1
         End If

--- a/Codigo/FileIO.bas
+++ b/Codigo/FileIO.bas
@@ -2281,6 +2281,9 @@ Public Sub CargarMapaFormatoCSM(ByVal map As Long, ByVal MAPFl As String)
 380     MapInfo(map).terrain = MapDat.terrain
 382     MapInfo(map).zone = MapDat.zone
 383     MapInfo(map).DropItems = True
+        If EsMapaNoDrop(map) Then
+            MapInfo(map).DropItems = False
+        End If
         MapInfo(map).FriendlyFire = True
         MapInfo(Map).KeepInviOnAttack = val(GetVar(DatPath & "Map.dat", "KeepInviOnAttack", Map)) <> 0
         MapInfo(Map).ForceUpdate = val(GetVar(DatPath & "Map.dat", "ForceUpdateAi", Map)) <> 0

--- a/Codigo/GameLogic.bas
+++ b/Codigo/GameLogic.bas
@@ -1701,18 +1701,29 @@ Public Sub CargarMapasEspeciales()
     
         
 117     Cantidad = val(File.GetValue("MapasEventos", "Cantidad"))
-    
+
 128     If Cantidad > 0 Then
 130         ReDim MapasEventos(1 To Cantidad)
-        
+
 132         For i = 1 To Cantidad
 134             MapasEventos(i) = val(File.GetValue("MapasEventos", "Mapa" & i))
             Next
         Else
 136         ReDim MapasEventos(0)
         End If
-        
-    
+
+140     Cantidad = val(File.GetValue("MapasNoDrop", "Cantidad"))
+
+142     If Cantidad > 0 Then
+144         ReDim MapasNoDrop(1 To Cantidad)
+
+146         For i = 1 To Cantidad
+148             MapasNoDrop(i) = val(File.GetValue("MapasNoDrop", "Mapa" & i))
+            Next
+        Else
+150         ReDim MapasNoDrop(0)
+        End If
+
 138     Set File = Nothing
 
 End Sub
@@ -1728,6 +1739,19 @@ Public Function EsMapaEvento(ByVal destMap As Long) As Boolean
     Next i
     EsMapaEvento = False
     
+End Function
+
+Public Function EsMapaNoDrop(ByVal destMap As Long) As Boolean
+    Dim i As Long
+
+    For i = 1 To UBound(MapasNoDrop)
+        If MapasNoDrop(i) = destMap Then
+            EsMapaNoDrop = True
+            Exit Function
+        End If
+    Next i
+    EsMapaNoDrop = False
+
 End Function
 
 Public Sub resetPj(ByVal UserIndex As Integer, Optional ByVal borrarHechizos As Boolean = False)


### PR DESCRIPTION
## Summary
- declara el nuevo arreglo `MapasNoDrop` y lo carga desde la sección `[MapasNoDrop]`
- marca los mapas sin drop durante `CargarMapaFormatoCSM` y bloquea `DropObj`/`TirarOro` cuando corresponda
- documenta la nueva sección de configuración y su efecto

## Testing
Probalo localhost OK Temis y ReyarB
