### PR TITLE
Hogar en Forgat por defecto

### DIFF
--- a/Codigo/TCP.bas
+++ b/Codigo/TCP.bas
@@ -645,7 +645,7 @@ Function ConnectNewUser(ByVal userindex As Integer, ByRef name As String, ByVal 
 154         .Char.Head = Head
         
 156         .genero = UserSexo
-158         .Hogar = Hogar
+158         .Hogar = cForgat
         
             '%%%%%%%%%%%%% PREVENIR HACKEO DE LOS SKILLS %%%%%%%%%%%%%
 160         .Stats.SkillPts = 10


### PR DESCRIPTION
Este cambio permite que al crear un personaje Forgat sea el HOGAR configurado por defecto, permitiendo al usuario cambiarlo si asi lo desea con cualquier Gobernador de otra ciudad.