### PR TITLE
Update tree depletion graphics handling

### DIFF
--- a/Codigo/PacketId.bas
+++ b/Codigo/PacketId.bas
@@ -209,6 +209,7 @@ Public Enum ServerPacketID
 #If PYMMO = 0 Then
     eAccountCharacterList
 #End If
+    eTileGraphicUpdate
     eMaxPacket
     [PacketCount]
 End Enum

--- a/Codigo/Protocol_Writes.bas
+++ b/Codigo/Protocol_Writes.bas
@@ -5196,6 +5196,25 @@ PrepareMessage_BlockPosition_Err:
         
 End Function
 
+Public Function PrepareMessageTileGraphicUpdate(ByVal X As Byte, _
+                                                ByVal Y As Byte, _
+                                                ByVal Grh As Long)
+
+        On Error GoTo PrepareMessageTileGraphicUpdate_Err
+
+100     Call Writer.WriteInt16(ServerPacketID.eTileGraphicUpdate)
+102     Call Writer.WriteInt8(X)
+104     Call Writer.WriteInt8(Y)
+106     Call Writer.WriteInt32(Grh)
+
+        Exit Function
+
+PrepareMessageTileGraphicUpdate_Err:
+        Call Writer.Clear
+        Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.PrepareMessageTileGraphicUpdate", Erl)
+
+End Function
+
 Public Function PrepareTrapUpdate(ByVal State As Byte, ByVal x As Byte, ByVal y As Byte)
     On Error GoTo PrepareTrapUpdate_Err
 100     Call Writer.WriteInt16(ServerPacketID.eUpdateTrap)


### PR DESCRIPTION
## Summary
- add a helper to update depleted tree tiles and restore their graphics when resources regenerate
- send a new TileGraphicUpdate packet so nearby clients refresh the tile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d04227ce70833392760ecec18c6dce