### PR TITLE
Fix hardcoding on TipoPocion and Subtype objects

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -950,6 +950,40 @@ Public Const FLAG_AGUA               As Byte = &H20
 
 Public Const FLAG_ARBOL              As Byte = &H40
 
+Public Enum e_SubObjType
+    FishingRod = 1
+    FishingNet = 2
+    AlchemyScissors = 3
+    AlchemyPot = 4
+    CarpentrySaw = 5
+    LumberjackAxe = 6
+    BlacksmithHammer = 7
+    MinerPicket = 8
+    TailoringSewing = 9
+End Enum
+
+Public Enum e_TipoPocion
+    Agility = 1
+    Strength = 2
+    Hp = 3
+    Mp = 4
+    Poison = 5
+    RemoveParalisis = 6
+    Stamina = 7
+    ChangeHead = 8
+    ChangeSex = 9
+    Invisibility = 10
+    CleanEverything = 13
+    Rune = 14
+    Divorce = 15
+    Legendary = 17
+    Particle = 18
+    ResetSkill = 19
+    Suicide = 21
+    ResetCharacter = 22
+    PoisonWeapon = 23
+End Enum
+
 ' CATEGORIAS PRINCIPALES
 Public Enum e_OBJType
 


### PR DESCRIPTION
Reutilizando tipos de objetos en desuso para el sistema de Skins, me doy cuenta que hay muchas cosas hardcoding en useInvItem y me puse a tiparlas. 

En el caso de las pociones viene bien tiparlas para poder distinguir fácilmente de qué poción se trata.
En el caso de los subtipos de ítems, lo mismo.

Además, removí varios userlist(userindex) de useInvItem ya que lo cachea y mejora la performance el With de la cabecera de la función, y no tenía sentido sino.  

@morgolock @RecoX 