### PR TITLE
Elimino envío de mensaje en AlquimistaConstruirItem

### DIFF
--- a/Codigo/Trabajo.bas
+++ b/Codigo/Trabajo.bas
@@ -1269,9 +1269,6 @@ Public Sub AlquimistaConstruirItem(ByVal UserIndex As Integer, ByVal ItemIndex A
         Call SubirSkill(UserIndex, e_Skill.Alquimia)
         Call UpdateUserInv(True, UserIndex, 0)
         UserList(UserIndex).Counters.Trabajando = UserList(UserIndex).Counters.Trabajando + 1
-    Else
-        ' Msg644=Lamentablemente no aprendiste la receta para crear esta poción.
-        Call WriteLocaleMsg(UserIndex, "644", e_FontTypeNames.FONTTYPE_INFOBOLD)
     End If
     Exit Sub
 AlquimistaConstruirItem_Err:
@@ -2739,7 +2736,7 @@ Public Function KnowsCraftingRecipe(ByVal UserIndex As Integer, ByVal ItemIndex 
         Exit Function
     End If
     If Not TieneHechizo(hIndex, UserIndex) Then
-        'no conoces la receta para fabricar este item
+        'Msg644=Lamentablemente no aprendiste la receta para crear este item.
         Call WriteLocaleMsg(UserIndex, 644, e_FontTypeNames.FONTTYPE_INFOBOLD)
         KnowsCraftingRecipe = False
         Exit Function


### PR DESCRIPTION
Se eliminó el bloque Else en AlquimistaConstruirItem, ya que la validación de recetas la hace KnowsCraftingRecipe, que ya envía el mensaje correspondiente al usuario cuando no conoce la receta.