### PR TITLE
Trigger autosave after dropping items

### DIFF
--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -389,6 +389,7 @@ Sub DropObj(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal num As Integer
                     Call CustomScenarios.UserDropItem(UserIndex, Slot, Map, x, y)
                     Call QuitarUserInvItem(UserIndex, Slot, num)
                     Call UpdateUserInv(False, UserIndex, Slot)
+                    Call SaveUser(UserIndex)
                     If .flags.jugando_captura = 1 Then
                         If Not InstanciaCaptura Is Nothing Then
                             Call InstanciaCaptura.tiraBandera(UserIndex, obj.ObjIndex)
@@ -405,6 +406,7 @@ Sub DropObj(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal num As Integer
             Else
                 Call QuitarUserInvItem(UserIndex, Slot, num)
                 Call UpdateUserInv(False, UserIndex, Slot)
+                Call SaveUser(UserIndex)
             End If
         End With
     End If


### PR DESCRIPTION
## Summary
- trigger a user save immediately after items are removed from the inventory during DropObj
- ensure both regular drops and destruction flows persist only the character who dropped the item

## Testing
- not run (VB6 server build not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6e09b626083338650d1b861a55938