### PR TITLE
Handle GetTickCount wraparound when computing elapsed time

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -3619,7 +3619,7 @@ End Sub
 ' log if there time betwen calls exced the limit
 Public Sub PerformTimeLimitCheck(ByRef timer As Long, ByRef TestText As String, Optional ByVal TimeLimit As Long = 1000)
     Dim CurrTime As Long
-    CurrTime = GetTickCount() - timer
+    CurrTime = TicksElapsed(timer)
     If CurrTime > TimeLimit Then
         Call LogPerformance("Performance warning at: " & TestText & " elapsed time: " & CurrTime)
     End If

--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -1420,7 +1420,7 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
             Exit Sub
         End If
         obj = ObjData(.invent.Object(Slot).ObjIndex)
-        Dim TimeSinceLastUse As Long: TimeSinceLastUse = GetTickCount() - .CdTimes(obj.cdType)
+        Dim TimeSinceLastUse As Long: TimeSinceLastUse = TicksElapsed(.CdTimes(obj.cdType))
         If TimeSinceLastUse < obj.Cooldown Then Exit Sub
         If IsSet(obj.ObjFlags, e_ObjFlags.e_UseOnSafeAreaOnly) Then
             If MapInfo(.pos.Map).Seguro = 0 Then
@@ -2059,7 +2059,7 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
                         Call UserMod.UserDie(UserIndex)
                         'Poción de reset (resetea el personaje)
                     Case 22
-                        If GetTickCount - .Counters.LastResetTick > 3000 Then
+                        If TicksElapsed(.Counters.LastResetTick) > 3000 Then
                             Call writeAnswerReset(UserIndex)
                             .Counters.LastResetTick = GetTickCount
                         Else
@@ -2733,7 +2733,7 @@ End Function
 
 Public Function IsItemInCooldown(ByRef User As t_User, ByRef obj As t_UserOBJ) As Boolean
     Dim ElapsedTime As Long
-    ElapsedTime = GetTickCount() - User.CdTimes(ObjData(obj.ObjIndex).cdType)
+    ElapsedTime = TicksElapsed(User.CdTimes(ObjData(obj.ObjIndex).cdType))
     IsItemInCooldown = ElapsedTime < ObjData(obj.ObjIndex).Cooldown
 End Function
 

--- a/Codigo/ModInvasion.bas
+++ b/Codigo/ModInvasion.bas
@@ -297,7 +297,7 @@ Public Sub EnviarInfoInvasion(ByVal Index As Integer)
     With Invasiones(Index)
         Dim PorcentajeVida As Byte, PorcentajeTiempo As Byte
         PorcentajeVida = (.VidaMuralla / .MaxVidaMuralla) * 100
-        PorcentajeTiempo = (GetTickCount - .TiempoDeInicio) / (.Duracion * 600)
+        PorcentajeTiempo = TicksElapsed(.TiempoDeInicio) / (.Duracion * 600)
         Dim i As Integer, Mapa As Integer, j As Integer
         For i = 1 To UBound(.SpawnBoxes)
             Mapa = .SpawnBoxes(i).TopLeft.Map

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -5916,7 +5916,7 @@ Private Sub HandleTransFerGold(ByVal UserIndex As Integer)
         End If
         If Not EsGM(UserIndex) Then
             If Not IsValidUserRef(tUser) Then
-                If GetTickCount() - .Counters.LastTransferGold >= 10000 Then
+                If TicksElapsed(.Counters.LastTransferGold) >= 10000 Then
                     If PersonajeExiste(username) Then
                         If Not AddOroBancoDatabase(username, Cantidad) Then
                             Call WriteLocaleChatOverHead(UserIndex, 1409, vbNullString, NpcList(.flags.TargetNPC.ArrayIndex).Char.charindex, vbWhite)  ' Msg1409=Error al realizar la operación.

--- a/Codigo/Protocol_Writes.bas
+++ b/Codigo/Protocol_Writes.bas
@@ -3732,7 +3732,7 @@ End Function
 Public Function PrepareMessageHora()
     On Error GoTo PrepareMessageHora_Err
     Call Writer.WriteInt16(ServerPacketID.ehora)
-    Call Writer.WriteInt32(CLng((GetTickCount() - HoraMundo) Mod CLng(SvrConfig.GetValue("DayLength"))))
+    Call Writer.WriteInt32(CLng((TicksElapsed(HoraMundo)) Mod CLng(SvrConfig.GetValue("DayLength"))))
     Call Writer.WriteInt32(CLng(SvrConfig.GetValue("DayLength")))
     Exit Function
 PrepareMessageHora_Err:
@@ -4378,7 +4378,7 @@ Public Sub WriteDebugLogResponse(ByVal UserIndex As Integer, ByVal debugType, By
             Call Writer.WriteString8("remote DEBUG: " & " user name: " & Args(0))
             With UserList(tIndex)
                 Dim timeSinceLastReset As Long
-                timeSinceLastReset = GetTickCount() - Mapping(.ConnectionDetails.ConnID).TimeLastReset
+                timeSinceLastReset = TicksElapsed(Mapping(.ConnectionDetails.ConnID).TimeLastReset)
                 Call Writer.WriteString8("validConnection: " & .ConnectionDetails.ConnIDValida & " connectionID: " & .ConnectionDetails.ConnID & " UserIndex: " & tIndex & _
                         " charNmae" & .name & " UserLogged state: " & .flags.UserLogged & ", time since last message: " & timeSinceLastReset & " timeout setting: " & _
                         DisconnectTimeout)

--- a/Codigo/ScenarioDeathMatch.cls
+++ b/Codigo/ScenarioDeathMatch.cls
@@ -413,7 +413,7 @@ End Sub
 
 Public Sub IBaseScenario_Update()
     Dim frametime As Long
-    frametime = GetTickCount() - LastFrameTime
+    frametime = TicksElapsed(LastFrameTime)
     LastFrameTime = GetTickCount()
     If LobbyList(LobbyIndex).State = e_LobbyState.InProgress Then
         If CountdownTimer.Occurrences < 10 Then

--- a/Codigo/ScenarioHuntNpc.cls
+++ b/Codigo/ScenarioHuntNpc.cls
@@ -263,7 +263,7 @@ End Sub
 
 Private Sub IBaseScenario_Update()
     Dim frametime As Long
-    frametime = GetTickCount() - LastFrameTime
+    frametime = TicksElapsed(LastFrameTime)
     LastFrameTime = GetTickCount()
     If LobbyList(LobbyIndex).State = e_LobbyState.InProgress Then
         If StartTimer.Occurrences < 10 Then

--- a/Codigo/Scenearios/ScenarioNavalBoarding.cls
+++ b/Codigo/Scenearios/ScenarioNavalBoarding.cls
@@ -487,7 +487,7 @@ End Sub
 
 Public Sub IBaseScenario_Update()
     Dim frametime As Long
-    frametime = GetTickCount() - LastFrameTime
+    frametime = TicksElapsed(LastFrameTime)
     LastFrameTime = GetTickCount()
     If LobbyList(LobbyIndex).State = e_LobbyState.InProgress Then
         If CountdownTimer.Occurrences < 10 Then

--- a/Codigo/frmMain.frm
+++ b/Codigo/frmMain.frm
@@ -1116,12 +1116,12 @@ Private Sub TimerGuardarUsuarios_Timer()
         For UserIndex = 1 To LastUser
             With UserList(UserIndex)
                 If .flags.UserLogged Then
-                    If GetTickCount - .Counters.LastSave > IntervaloGuardarUsuarios Then
+                    If TicksElapsed(.Counters.LastSave) > IntervaloGuardarUsuarios Then
                         Call SaveUser(UserIndex)
                         UserGuardados = UserGuardados + 1
                         If UserGuardados > NumUsers Then Exit For
                         'limit the amount of time we block the only thread we have here, lets save some user on the next loop
-                        If (GetTickCount - PerformanceTimer) > 100 Then Exit For
+                        If (TicksElapsed(PerformanceTimer)) > 100 Then Exit For
                     End If
                 End If
             End With
@@ -1386,7 +1386,7 @@ Private Sub Automatic_Event_Timer()
     End If
     If AlreadyDidAutoEventToday Then
         '3600000 = 1 hora en milisegundos
-        If GetTickCount - LastAutoEventAttempt > 3600000 Then
+        If TicksElapsed(LastAutoEventAttempt) > 3600000 Then
             AlreadyDidAutoEventToday = False
         End If
         Exit Sub

--- a/Codigo/modTime.bas
+++ b/Codigo/modTime.bas
@@ -31,6 +31,8 @@ Private Declare Function timeGetTime Lib "winmm.dll" () As Long
 Private Declare Sub GetSystemTime Lib "kernel32.dll" (lpSystemTime As t_SYSTEMTIME)
 Private theTime As t_SYSTEMTIME
 
+Private Const MAX_TICKS As Double = 2147483648#
+
 Private Type t_SYSTEMTIME
     wYear As Integer
     wMonth As Integer
@@ -57,10 +59,22 @@ GetTickCount_Err:
     Call TraceError(Err.Number, Err.Description, "ModLadder.GetTickCount", Erl)
 End Function
 
+Public Function TicksElapsed(ByVal EarlierTick As Long, Optional ByVal LaterTick As Long = -1) As Long
+    If LaterTick = -1 Then
+        LaterTick = GetTickCount()
+    End If
+
+    If LaterTick >= EarlierTick Then
+        TicksElapsed = LaterTick - EarlierTick
+    Else
+        TicksElapsed = CLng((MAX_TICKS - EarlierTick) + LaterTick)
+    End If
+End Function
+
 Function GetTimeFormated() As String
     On Error GoTo GetTimeFormated_Err
     Dim Elapsed As Long
-    Elapsed = (GetTickCount() - HoraMundo) / SvrConfig.GetValue("DayLength")
+    Elapsed = (TicksElapsed(HoraMundo)) / SvrConfig.GetValue("DayLength")
     Dim Mins As Long
     Mins = (Elapsed - Fix(Elapsed)) * 1440
     Dim Horita    As Byte


### PR DESCRIPTION
## Summary
- add a TicksElapsed helper that normalizes GetTickCount deltas across the 31-bit wrap boundary
- replace direct GetTickCount subtraction in timers, cooldowns, and scenario updates to rely on the helper
- keep world time formatting and debug reporting stable when the tick counter overflows

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d97978a0c083339302b7e3cdf8c302