### PR TITLE
fix(protocol): prevent negative world time in PrepareMessageHora

### DIFF
--- a/Codigo/General.bas
+++ b/Codigo/General.bas
@@ -556,13 +556,15 @@ Sub Main()
     '           Configuracion de los sockets
     ' ----------------------------------------------------
     Call GetHoraActual
-    HoraMundo = GetTickCount() - SvrConfig.GetValue("DayLength") \ 2
+    HoraMundo = GetTickCountRaw() - SvrConfig.GetValue("DayLength") \ 2
     frmCargando.Visible = False
     Unload frmCargando
     'Ocultar
     Call frmMain.InitMain(HideMe)
     Call InitializeAntiCheat
-    tInicioServer = GetTickCount()
+    tInicioServer = GetTickCountRaw()
+
+
     #If UNIT_TEST = 1 Then
         Call UnitTesting.Init
         Debug.Print "AO20 Unit Testing"

--- a/Codigo/PacketId.bas
+++ b/Codigo/PacketId.bas
@@ -324,7 +324,6 @@ Public Enum ClientPacketID
     eOnlineChaosLegion       '/ONLINECAOS
     eGoNearby                '/IRCERCA
     ecomment                 '/REM
-    eserverTime              '/HORA
     eWhere                   '/DONDE
     eCreaturesInMap          '/NENE
     eWarpMeToTarget          '/TELEPLOC
@@ -425,7 +424,6 @@ Public Enum ClientPacketID
     eSaveChars               '/GRABAR
     eCleanSOS                '/BORRAR SOS
     eShowServerForm          '/SHOW INT
-    enight                   '/NOCHE
     eKickAllChars            '/ECHARTODOSPJS
     eReloadNPCs              '/RELOADNPCS
     eReloadServerIni         '/RELOADSINI
@@ -439,8 +437,6 @@ Public Enum ClientPacketID
     eGlobalMessage           '/CONSOLA
     eGlobalOnOff
     eUseKey
-    eDay
-    eSetTime
     eDonateGold              '/DONAR
     ePromedio                '/PROMEDIO
     eGiveItem                '/DAR

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -463,8 +463,6 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
             Call HandleGoNearby(UserIndex)
         Case ClientPacketID.ecomment
             Call HandleComment(UserIndex)
-        Case ClientPacketID.eserverTime
-            Call HandleServerTime(UserIndex)
         Case ClientPacketID.eWhere
             Call HandleWhere(UserIndex)
         Case ClientPacketID.eCreaturesInMap
@@ -677,8 +675,6 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
             Call HandleCleanSOS(UserIndex)
         Case ClientPacketID.eShowServerForm
             Call HandleShowServerForm(UserIndex)
-        Case ClientPacketID.enight
-            Call HandleNight(UserIndex)
         Case ClientPacketID.eKickAllChars
             Call HandleKickAllChars(UserIndex)
         Case ClientPacketID.eReloadNPCs
@@ -703,10 +699,6 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
             Call HandleGlobalOnOff(UserIndex)
         Case ClientPacketID.eUseKey
             Call HandleUseKey(UserIndex)
-        Case ClientPacketID.eDay
-            Call HandleDay(UserIndex)
-        Case ClientPacketID.eSetTime
-            Call HandleSetTime(UserIndex)
         Case ClientPacketID.eDonateGold
             Call HandleDonateGold(UserIndex)
         Case ClientPacketID.ePromedio
@@ -4847,22 +4839,6 @@ Private Sub HandleComment(ByVal UserIndex As Integer)
     Exit Sub
 ErrHandler:
     Call TraceError(Err.Number, Err.Description, "Protocol.HandleComment", Erl)
-End Sub
-
-''
-' Handles the "ServerTime" message.
-'
-' @param    UserIndex The index of the user sending the message.
-Private Sub HandleServerTime(ByVal UserIndex As Integer)
-    On Error GoTo HandleServerTime_Err
-    With UserList(UserIndex)
-        If .flags.Privilegios And e_PlayerType.User Then Exit Sub
-        Call LogGM(.name, "Hora.")
-    End With
-    Call modSendData.SendData(SendTarget.ToAll, 0, PrepareMessageLocaleMsg(1814, Time & "¬" & Date, e_FontTypeNames.FONTTYPE_INFO)) ' Msg1814=Hora: ¬1 ¬2
-    Exit Sub
-HandleServerTime_Err:
-    Call TraceError(Err.Number, Err.Description, "Protocol.HandleServerTime", Erl)
 End Sub
 
 Private Sub HandleUseKey(ByVal UserIndex As Integer)

--- a/Codigo/Protocol_GmCommands.bas
+++ b/Codigo/Protocol_GmCommands.bas
@@ -89,7 +89,7 @@ Public Sub HandleUpTime(ByVal UserIndex As Integer)
     Dim Time      As Long
     Dim UpTimeStr As String
     'Get total time in seconds
-    Time = ((GetTickCount()) - tInicioServer) \ 1000
+    Time = TicksElapsed(tInicioServer, GetTickCountRaw()) \ 1000
     'Get times in dd:hh:mm:ss format
     UpTimeStr = (Time Mod 60) & " segundos."
     Time = Time \ 60
@@ -3263,23 +3263,7 @@ HandleShowServerForm_Err:
     Call TraceError(Err.Number, Err.Description, "Protocol.HandleShowServerForm", Erl)
 End Sub
 
-Public Sub HandleNight(ByVal UserIndex As Integer)
-    On Error GoTo HandleNight_Err
-    'Author: Lucas Tavolaro Ortiz (Tavo)
-    'Last modified by: Juan Martín Sotuyo Dodero (Maraxus)
-    With UserList(UserIndex)
-        If (.flags.Privilegios And (e_PlayerType.User Or e_PlayerType.Consejero Or e_PlayerType.RoleMaster)) Then
-            'Msg528=Servidor » Comando deshabilitado para tu cargo.
-            Call WriteLocaleMsg(UserIndex, "528", e_FontTypeNames.FONTTYPE_INFO)
-            Exit Sub
-        End If
-        HoraMundo = GetTickCount()
-        Call SendData(SendTarget.ToAll, 0, PrepareMessageHora())
-    End With
-    Exit Sub
-HandleNight_Err:
-    Call TraceError(Err.Number, Err.Description, "Protocol.HandleNight", Erl)
-End Sub
+
 
 Public Sub HandleKickAllChars(ByVal UserIndex As Integer)
     On Error GoTo HandleKickAllChars_Err
@@ -3475,39 +3459,6 @@ HandleGlobalOnOff_Err:
     Call TraceError(Err.Number, Err.Description, "Protocol.HandleGlobalOnOff", Erl)
 End Sub
 
-Public Sub HandleDay(ByVal UserIndex As Integer)
-    On Error GoTo HandleDay_Err
-    With UserList(UserIndex)
-        If (.flags.Privilegios And (e_PlayerType.User Or e_PlayerType.Consejero Or e_PlayerType.SemiDios)) Then
-            'Msg528=Servidor » Comando deshabilitado para tu cargo.
-            Call WriteLocaleMsg(UserIndex, "528", e_FontTypeNames.FONTTYPE_INFO)
-            Exit Sub
-        End If
-        HoraMundo = GetTickCount() - SvrConfig.GetValue("DayLength") \ 2
-        Call SendData(SendTarget.ToAll, 0, PrepareMessageHora())
-    End With
-    Exit Sub
-HandleDay_Err:
-    Call TraceError(Err.Number, Err.Description, "Protocol.HandleDay", Erl)
-End Sub
-
-Public Sub HandleSetTime(ByVal UserIndex As Integer)
-    On Error GoTo HandleSetTime_Err
-    With UserList(UserIndex)
-        Dim HoraDia As Long
-        HoraDia = reader.ReadInt32
-        If (.flags.Privilegios And (e_PlayerType.User Or e_PlayerType.Consejero Or e_PlayerType.SemiDios)) Then
-            'Msg528=Servidor » Comando deshabilitado para tu cargo.
-            Call WriteLocaleMsg(UserIndex, "528", e_FontTypeNames.FONTTYPE_INFO)
-            Exit Sub
-        End If
-        HoraMundo = GetTickCount() - HoraDia
-        Call SendData(SendTarget.ToAll, 0, PrepareMessageHora())
-    End With
-    Exit Sub
-HandleSetTime_Err:
-    Call TraceError(Err.Number, Err.Description, "Protocol.HandleSetTime", Erl)
-End Sub
 
 Public Sub HandleGiveItem(ByVal UserIndex As Integer)
     On Error GoTo ErrHandler

--- a/Codigo/Protocol_Writes.bas
+++ b/Codigo/Protocol_Writes.bas
@@ -3729,16 +3729,35 @@ PrepareMessageRainToggle_Err:
     Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.PrepareMessageRainToggle", Erl)
 End Function
 
+
 Public Function PrepareMessageHora()
     On Error GoTo PrepareMessageHora_Err
+
+    Dim dayLen As Long
+    dayLen = CLng(SvrConfig.GetValue("DayLength"))
+    If dayLen <= 0 Then dayLen = 1 ' guard
+
+    Dim nowTicks As Long
+    nowTicks = GetTickCount()
+
+    ' HoraMundo should be a GetTickCount() snapshot of when the in-game day started
+    Dim elapsed As Double
+    elapsed = TicksElapsed(HoraMundo, nowTicks)
+
+    Dim t As Long
+    t = PosMod(elapsed, dayLen)  ' always 0..dayLen-1
+
     Call Writer.WriteInt16(ServerPacketID.ehora)
-    Call Writer.WriteInt32(CLng((GetTickCount() - HoraMundo) Mod CLng(SvrConfig.GetValue("DayLength"))))
-    Call Writer.WriteInt32(CLng(SvrConfig.GetValue("DayLength")))
+    Call Writer.WriteInt32(t)
+    Call Writer.WriteInt32(dayLen)
     Exit Function
+
 PrepareMessageHora_Err:
     Call Writer.Clear
-    Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.PrepareMessageHora", Erl)
+    Call TraceError(Err.Number, Err.Description, _
+        "Argentum20Server.Protocol_Writes.PrepareMessageHora", Erl)
 End Function
+
 
 ''
 ' Prepares the "ObjectDelete" message and returns it.

--- a/Codigo/modElapsedTime.bas
+++ b/Codigo/modElapsedTime.bas
@@ -1,0 +1,38 @@
+Attribute VB_Name = "modElapsedTime"
+' === modTicksMasked.bas ===
+Option Explicit
+
+Private Declare Function timeGetTime Lib "winmm.dll" () As Long
+
+Private Const TICKS32 As Double = 4294967296#
+
+' Legacy (keep for now, used by old code paths)
+Public Function GetTickCount() As Long
+    GetTickCount = timeGetTime() And &H7FFFFFFF
+End Function
+
+' New raw version (preferred)
+Public Function GetTickCountRaw() As Long
+    GetTickCountRaw = timeGetTime()
+End Function
+
+Public Function TicksElapsed(ByVal startTick As Long, ByVal currentTick As Long) As Double
+    If currentTick >= startTick Then
+        TicksElapsed = CDbl(currentTick - startTick)
+    Else
+        TicksElapsed = (TICKS32 - CDbl(startTick)) + CDbl(currentTick)
+    End If
+End Function
+
+Public Function TickAfter(ByVal a As Long, ByVal b As Long) As Boolean
+    TickAfter = (a - b) >= 0
+End Function
+
+Public Function PosMod(ByVal a As Double, ByVal m As Long) As Long
+    If m <= 0 Then PosMod = 0: Exit Function
+    Dim r As Double
+    r = a - m * Fix(a / m)
+    If r >= m Then r = r - m
+    If r < 0 Then r = r + m
+    PosMod = CLng(r)
+End Function

--- a/Codigo/modTime.bas
+++ b/Codigo/modTime.bas
@@ -27,7 +27,7 @@ Attribute VB_Name = "modTime"
 '
 '
 Option Explicit
-Private Declare Function timeGetTime Lib "winmm.dll" () As Long
+
 Private Declare Sub GetSystemTime Lib "kernel32.dll" (lpSystemTime As t_SYSTEMTIME)
 Private theTime As t_SYSTEMTIME
 
@@ -48,14 +48,6 @@ Public Type t_Timer
     Occurrences As Integer
 End Type
 
-Public Function GetTickCount() As Long
-    On Error GoTo GetTickCount_Err
-    'recovers time as MILISECONDS
-    GetTickCount = timeGetTime And &H7FFFFFFF
-    Exit Function
-GetTickCount_Err:
-    Call TraceError(Err.Number, Err.Description, "ModLadder.GetTickCount", Erl)
-End Function
 
 Function GetTimeFormated() As String
     On Error GoTo GetTimeFormated_Err

--- a/Server.VBP
+++ b/Server.VBP
@@ -131,6 +131,7 @@ Class=clsNetWriter; Codigo\clsNetWriter.cls
 Module=StringUtils; Codigo\StringUtils.bas
 Module=Consts; Codigo\Consts.bas
 Module=modUptime; Codigo\modUptime.bas
+Module=modElapsedTime; Codigo\modElapsedTime.bas
 IconForm="frmMain"
 Startup="Sub Main"
 HelpFile=""


### PR DESCRIPTION
- Removed packts eServerTime, eNight, eDay, eSetTime
- Replaced naive subtraction with wrap-aware elapsed calculation
- Use `TicksElapsed32` and `PosMod` to handle 32-bit tick counter wrap (2^32 ms)
- Ensure server always sends a non-negative elapsed time in [0, DayLength)
- This prevents clients from receiving negative world times when GetTickCount wraps