### PR TITLE
fix(stun): migrate StunEndTime to wrap-safe raw tick logic

### DIFF
--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -1434,16 +1434,27 @@ Public Sub KillRandomNpc()
     Call MuereNpc(NpcIndex, 0)
 End Sub
 
+
 Public Function CanMove(ByRef counter As t_NpcCounters, ByRef flags As t_NPCFlags) As Boolean
-    CanMove = flags.Inmovilizado + flags.Paralizado = 0 And counter.StunEndTime < GetTickCount() And Not flags.TranslationActive
+    Dim nowRaw As Long
+    nowRaw = GetTickCountRaw()
+
+    CanMove = _
+        (flags.Inmovilizado + flags.Paralizado = 0) _
+        And TickAfter(nowRaw, counter.StunEndTime) _
+        And Not flags.TranslationActive
 End Function
 
 Public Function CanAttack(ByRef counter As t_NpcCounters, ByRef flags As t_NPCFlags) As Boolean
-    CanAttack = flags.Paralizado = 0 And counter.StunEndTime < GetTickCount()
+    Dim nowRaw As Long
+    nowRaw = GetTickCountRaw()
+
+    CanAttack = (flags.Paralizado = 0) _
+                And TickAfter(nowRaw, counter.StunEndTime)
 End Function
 
 Public Sub StunNPc(ByRef Counters As t_NpcCounters)
-    Counters.StunEndTime = GetTickCount() + NpcStunTime
+    Counters.StunEndTime = AddMod32(GetTickCountRaw(), NpcStunTime)
 End Sub
 
 Public Function ModifyHealth(ByVal NpcIndex As Integer, ByVal amount As Long, Optional ByVal MinValue = 0) As Boolean

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -2602,24 +2602,43 @@ Public Sub ClearClothes(ByRef Char As t_Char)
 End Sub
 
 Public Function IsStun(ByRef flags As t_UserFlags, ByRef Counters As t_UserCounters) As Boolean
-    IsStun = Counters.StunEndTime > GetTickCount()
+    Dim nowRaw As Long
+    nowRaw = GetTickCountRaw()
+
+    ' Player is stunned if current tick has NOT yet passed the stun end deadline
+    IsStun = Not TickAfter(nowRaw, Counters.StunEndTime)
 End Function
+
 
 Public Function CanMove(ByRef flags As t_UserFlags, ByRef Counters As t_UserCounters) As Boolean
     CanMove = flags.Paralizado = 0 And flags.Inmovilizado = 0 And Not IsStun(flags, Counters) And Not flags.TranslationActive
 End Function
 
+
 Public Function StunPlayer(ByVal UserIndex As Integer, ByRef Counters As t_UserCounters) As Boolean
-    Dim CurrTime As Long
+    On Error GoTo EH
     StunPlayer = False
+
+    ' (Optional) your CanMove signature might be (counters, flags) — adjust order if needed
     If Not CanMove(UserList(UserIndex).flags, Counters) Then Exit Function
     If IsSet(UserList(UserIndex).flags.StatusMask, eCCInmunity) Then Exit Function
-    CurrTime = GetTickCount()
-    If CurrTime > Counters.StunEndTime + PlayerInmuneTime Then
-        Counters.StunEndTime = GetTickCount() + PlayerStunTime
+
+    Dim nowRaw As Long
+    nowRaw = GetTickCountRaw()   ' <-- use raw tick
+
+    ' Respect anti-chain-stun window: allow new stun only after immune window passes
+    Dim immuneUntil As Long
+    immuneUntil = AddMod32(Counters.StunEndTime, PlayerInmuneTime) ' old end + immunity
+
+    If TickAfter(nowRaw, immuneUntil) Then
+        ' Apply (or re-apply) stun: set absolute deadline using modulo-2^32 add
+        Counters.StunEndTime = AddMod32(nowRaw, PlayerStunTime)
         StunPlayer = True
     End If
+    Exit Function
+EH:
 End Function
+
 
 Public Function CanUseItem(ByRef flags As t_UserFlags, ByRef Counters As t_UserCounters) As Boolean
     CanUseItem = True


### PR DESCRIPTION
#### What was changed

* Migrated all **stun timing logic** to use wrap-safe raw tick functions.
* `StunEndTime` is now set as an absolute deadline with:

  ```vb
  StunEndTime = AddMod32(GetTickCountRaw(), durationMs)
  ```
* Updated checks:

  * **CanMove / CanAttack** → `TickAfter(nowRaw, StunEndTime)`
  * **IsStun** → `Not TickAfter(nowRaw, StunEndTime)`
  * **StunPlayer** → applies stun only after immune window using `AddMod32` + `TickAfter`.

#### Why

* The old implementation used masked `GetTickCount()` and naive comparisons (`>`, `<`).
* When the tick counter wrapped (~24.9 days with masked version), these comparisons went negative and broke stun/cooldown logic.
* This could cause players or NPCs to remain stunned indefinitely or bypass stuns after a wrap.

#### Benefits

* All stun-related checks are now **robust across tick wrap** (~49.7 days).
* Behavior is consistent regardless of server uptime.
* Standardized use of `GetTickCountRaw()`, `AddMod32()`, and `TickAfter()` makes the logic easier to read and maintain.
