### PR TITLE
Fix Skill Requerido en Quest

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -3650,3 +3650,34 @@ Public Sub PerformTimeLimitCheck(ByRef timer As Long, ByRef TestText As String, 
     End If
     timer = GetTickCount()
 End Sub
+
+Public Function SkillRequerido(ByVal SkillType As Integer) As String
+    Select Case SkillType
+        Case 1: SkillRequerido = "Magia"
+        Case 2: SkillRequerido = "Robar"
+        Case 3: SkillRequerido = "Destreza en Combate"
+        Case 4: SkillRequerido = "Combate con Armas"
+        Case 5: SkillRequerido = "Meditar"
+        Case 6: SkillRequerido = "Apuñalar"
+        Case 7: SkillRequerido = "Ocultarse"
+        Case 8: SkillRequerido = "Supervivencia"
+        Case 9: SkillRequerido = "Comerciar"
+        Case 10: SkillRequerido = "Defensa con Escudos"
+        Case 11: SkillRequerido = "Liderazgo"
+        Case 12: SkillRequerido = "Armas a Distancia"
+        Case 13: SkillRequerido = "Combate sin Armas"
+        Case 14: SkillRequerido = "Navegación"
+        Case 15: SkillRequerido = "Equitación"
+        Case 16: SkillRequerido = "Resistencia Mágica"
+        Case 17: SkillRequerido = "Talar"
+        Case 18: SkillRequerido = "Pescar"
+        Case 19: SkillRequerido = "Minería"
+        Case 20: SkillRequerido = "Herrería"
+        Case 21: SkillRequerido = "Carpintería"
+        Case 22: SkillRequerido = "Alquimia"
+        Case 23: SkillRequerido = "Sastrería"
+        Case 24: SkillRequerido = "Domar"
+        Case Else
+            SkillRequerido = "Habilidad desconocida"
+    End Select
+End Function

--- a/Codigo/ModQuest.bas
+++ b/Codigo/ModQuest.bas
@@ -614,12 +614,11 @@ Public Function CanUserAcceptQuest(ByVal UserIndex As Integer, ByVal NpcIndex As
             Exit Function
         End If
     End If
-    If tmpQuest.RequiredSkill.SkillType > 0 Then
+   If tmpQuest.RequiredSkill.SkillType > 0 Then
         If UserList(UserIndex).Stats.UserSkills(tmpQuest.RequiredSkill.SkillType) < tmpQuest.RequiredSkill.RequiredValue Then
-            Call WriteLocaleMsg(UserIndex, 473, e_FontTypeNames.FONTTYPE_INFO)
+         Call WriteLocaleMsg(UserIndex, 473, e_FontTypeNames.FONTTYPE_INFO, SkillRequerido(tmpQuest.RequiredSkill.SkillType))
             Exit Function
         End If
-    End If
     If UserList(UserIndex).clase <> tmpQuest.RequiredClass And tmpQuest.RequiredClass > 0 Then
         Call WriteLocaleMsg(UserIndex, 1426, e_FontTypeNames.FONTTYPE_INFO)
         Exit Function
@@ -634,4 +633,5 @@ Public Function CanUserAcceptQuest(ByVal UserIndex As Integer, ByVal NpcIndex As
     Exit Function
 ErrHandler:
     Call TraceError(Err.Number, Err.Description, "ModQuest.CanUserAcceptQuest", Erl)
+    End If
 End Function


### PR DESCRIPTION
Se agregó una función SkillRequerido(SkillType As Integer) As String en ModSkills.bas para traducir el ID numérico de una habilidad a su nombre correspondiente.

Se actualizó la validación de requisitos de quest en CanUserAcceptQuest (ModQuest.bas), reemplazando la salida del número de skill (SkillType) por su nombre descriptivo. 

Ahora, cuando un jugador no cumple con el requisito de skill, el mensaje en pantalla muestra correctamente el nombre de la habilidad en lugar del número.