### PR TITLE
Enviar ID de skill en mensaje de quests

### DIFF
--- a/Codigo/ModQuest.bas
+++ b/Codigo/ModQuest.bas
@@ -616,7 +616,7 @@ Public Function CanUserAcceptQuest(ByVal UserIndex As Integer, ByVal NpcIndex As
     End If
     If tmpQuest.RequiredSkill.SkillType > 0 Then
         If UserList(UserIndex).Stats.UserSkills(tmpQuest.RequiredSkill.SkillType) < tmpQuest.RequiredSkill.RequiredValue Then
-            Call WriteLocaleMsg(UserIndex, 473, e_FontTypeNames.FONTTYPE_INFO)
+            Call WriteLocaleMsg(UserIndex, 473, e_FontTypeNames.FONTTYPE_INFO, tmpQuest.RequiredSkill.SkillType)
             Exit Function
         End If
     End If


### PR DESCRIPTION
Se modifica el mensaje para enviar el ID del skill requerido (tmpQuest.RequiredSkill.SkillType) al cliente.