### PR TITLE
Block fishing rod use while standing on water

### DIFF
--- a/Codigo/Trabajo.bas
+++ b/Codigo/Trabajo.bas
@@ -104,9 +104,17 @@ Public Sub Trabajar(ByVal UserIndex As Integer, ByVal Skill As e_Skill)
                     Case e_ToolsSubtype.eFishingRod
                         If (MapData(.pos.Map, .Trabajo.Target_X, .Trabajo.Target_Y).Blocked And FLAG_AGUA) <> 0 And Not MapData(.pos.Map, .pos.x, .pos.y).trigger = _
                                 e_Trigger.PESCAINVALIDA Then
-                            If (MapData(.pos.Map, .pos.x, .pos.y).Blocked And FLAG_AGUA) <> 0 Or (MapData(.pos.Map, .pos.x + 1, .pos.y).Blocked And FLAG_AGUA) <> 0 Or (MapData( _
-                                    .pos.Map, .pos.x, .pos.y + 1).Blocked And FLAG_AGUA) <> 0 Or (MapData(.pos.Map, .pos.x - 1, .pos.y).Blocked And FLAG_AGUA) <> 0 Or (MapData( _
-                                    .pos.Map, .pos.x, .pos.y - 1).Blocked And FLAG_AGUA) <> 0 Then
+                            Dim isStandingOnWater As Boolean
+                            Dim isAdjacentToWater As Boolean
+
+                            isStandingOnWater = (MapData(.pos.Map, .pos.x, .pos.y).Blocked And FLAG_AGUA) <> 0
+                            isAdjacentToWater = (MapData(.pos.Map, .pos.x + 1, .pos.y).Blocked And FLAG_AGUA) <> 0 Or (MapData(.pos.Map, .pos.x, .pos.y + 1).Blocked And FLAG_AGUA) <> 0 Or (MapData( _
+                                    .pos.Map, .pos.x - 1, .pos.y).Blocked And FLAG_AGUA) <> 0 Or (MapData(.pos.Map, .pos.x, .pos.y - 1).Blocked And FLAG_AGUA) <> 0
+
+                            If isStandingOnWater Then
+                                Call WriteLocaleMsg(UserIndex, "1436", e_FontTypeNames.FONTTYPE_INFO)
+                                Call WriteMacroTrabajoToggle(UserIndex, False)
+                            ElseIf isAdjacentToWater Then
                                 .flags.PescandoEspecial = False
                                 If UserList(UserIndex).flags.Navegando = 0 Then
                                     If MapInfo(.pos.Map).zone = "DUNGEON" Then


### PR DESCRIPTION
## Summary
- prevent fishing with a rod while the player is standing on a water tile
- reuse the existing shoreline proximity checks to only allow fishing from adjacent land tiles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2ee6c6b048333aa9cc120b7bf42fc