### PR TITLE
Make automatic weather more frequent and consistent

### DIFF
--- a/Codigo/ModClimas.bas
+++ b/Codigo/ModClimas.bas
@@ -35,6 +35,33 @@ Public ServidorNublado     As Boolean
 Public ProbabilidadNublar  As Byte
 Public ProbabilidadLLuvia  As Byte
 
+Public Const METEOROLOGICAL_CYCLE_MINUTES                    As Byte = 20
+Public Const METEOROLOGICAL_CLOUD_COUNTDOWN_MINUTES          As Byte = 11
+Public Const METEOROLOGICAL_PRECIPITATION_COUNTDOWN_MINUTES  As Byte = 6
+
+Public Function WeatherCloudRollSucceeds(ByVal Roll As Byte) As Boolean
+    WeatherCloudRollSucceeds = (Roll = 1)
+End Function
+
+Public Function WeatherPrecipitationRollSucceeds(ByVal Roll As Byte, ByVal Cloudy As Boolean) As Boolean
+    WeatherPrecipitationRollSucceeds = Cloudy And Roll >= 1 And Roll <= 2
+End Function
+
+Public Sub SetAtmosphericFogState(ByVal Active As Boolean, Optional ByVal Intensity As Byte = 0)
+    ServidorNublado = Active
+    Nieblando = Active
+    If Active Then
+        IntensidadDeNubes = Intensity
+    Else
+        IntensidadDeNubes = 0
+    End If
+End Sub
+
+Public Sub SetPrecipitationState(ByVal Active As Boolean)
+    Lloviendo = Active
+    Nebando = Active
+End Sub
+
 Public Function IsAtmosphericFogActive() As Boolean
     IsAtmosphericFogActive = ServidorNublado Or Nieblando
 End Function
@@ -56,19 +83,24 @@ Public Sub ResetMeteo(Optional ByVal NotifyClients As Boolean = False)
     Dim NotifyRain As Boolean
     Dim NotifySnow As Boolean
     Dim NotifyFog As Boolean
+    Dim PreviousFogIntensity As Byte
+    PreviousFogIntensity = IntensidadDeNubes
     Call DetermineWeatherResetNotifications(Lloviendo, Nebando, IsAtmosphericFogActive(), NotifyRain, NotifySnow, NotifyFog)
     Call AgregarAConsola("Servidor > Meteorologia reseteada")
     frmMain.TimerMeteorologia.Enabled = True
     frmMain.Truenos.Enabled = False
-    TimerMeteorologico = 30
-    ServidorNublado = False
-    Nieblando = False
-    Lloviendo = False
-    Nebando = False
+    TimerMeteorologico = METEOROLOGICAL_CYCLE_MINUTES
+    Call SetAtmosphericFogState(False)
+    Call SetPrecipitationState(False)
+    ProbabilidadNublar = 0
+    ProbabilidadLLuvia = 0
+    IntensidadDeLluvias = 0
+    CapasLlueveEn = 0
+    DuracionDeLLuvia = 0
     If NotifyClients Then
         ' Fog has no explicit state in its packet: only toggle clients that
         ' were known to have atmospheric fog active before this reset.
-        If NotifyFog Then Call SendData(SendTarget.ToAll, 0, PrepareMessageNieblandoToggle(IntensidadDeNubes))
+        If NotifyFog Then Call SendData(SendTarget.ToAll, 0, PrepareMessageNieblandoToggle(PreviousFogIntensity))
         If NotifyRain Then Call SendData(SendTarget.ToAll, 0, PrepareMessageRainToggle())
         If NotifySnow Then Call SendData(SendTarget.ToAll, 0, PrepareMessageNevarToggle())
     End If

--- a/Codigo/Protocol_GmCommands.bas
+++ b/Codigo/Protocol_GmCommands.bas
@@ -3465,7 +3465,18 @@ Public Sub HandleNieblaToggle(ByVal UserIndex As Integer)
             Exit Sub
         End If
         Call LogGM(GetUserRealName(UserIndex), "/NIEBLA")
-        Call ResetMeteo(True)
+        Dim EnableFog As Boolean
+        Dim FogIntensity As Byte
+        EnableFog = Not IsAtmosphericFogActive()
+        If EnableFog Then
+            FogIntensity = RandomNumber(10, 45)
+            Call SetAtmosphericFogState(True, FogIntensity)
+        Else
+            FogIntensity = IntensidadDeNubes
+            Call SetAtmosphericFogState(False)
+            frmMain.Truenos.Enabled = False
+        End If
+        Call SendData(SendTarget.ToAll, 0, PrepareMessageNieblandoToggle(FogIntensity))
     End With
     Exit Sub
 HandleNieblaToggle_Err:

--- a/Codigo/Tests/Unit_Weather.bas
+++ b/Codigo/Tests/Unit_Weather.bas
@@ -4,6 +4,9 @@ Option Explicit
 
 Public Function test_suite_weather() As Boolean
     Call UnitTesting.RunTest("test_weather_fog_state", test_weather_fog_state())
+    Call UnitTesting.RunTest("test_weather_schedule_configuration", test_weather_schedule_configuration())
+    Call UnitTesting.RunTest("test_weather_probability_decisions", test_weather_probability_decisions())
+    Call UnitTesting.RunTest("test_weather_state_transitions", test_weather_state_transitions())
     Call UnitTesting.RunTest("test_weather_reset_decisions", test_weather_reset_decisions())
     Call UnitTesting.RunTest("test_weather_initial_sync", test_weather_initial_sync())
     Call UnitTesting.RunTest("test_weather_canonical_reset", test_weather_canonical_reset())
@@ -20,6 +23,35 @@ Private Function test_weather_fog_state() As Boolean
     ServidorNublado = False
     Nieblando = False
     test_weather_fog_state = Not IsAtmosphericFogActive()
+End Function
+
+Private Function test_weather_schedule_configuration() As Boolean
+    test_weather_schedule_configuration = METEOROLOGICAL_CYCLE_MINUTES = 20 And _
+        METEOROLOGICAL_CLOUD_COUNTDOWN_MINUTES = 11 And _
+        METEOROLOGICAL_PRECIPITATION_COUNTDOWN_MINUTES = 6
+End Function
+
+Private Function test_weather_probability_decisions() As Boolean
+    If Not WeatherCloudRollSucceeds(1) Then Exit Function
+    If WeatherCloudRollSucceeds(2) Then Exit Function
+    If Not WeatherPrecipitationRollSucceeds(1, True) Then Exit Function
+    If Not WeatherPrecipitationRollSucceeds(2, True) Then Exit Function
+    If WeatherPrecipitationRollSucceeds(3, True) Then Exit Function
+    If WeatherPrecipitationRollSucceeds(1, False) Then Exit Function
+    test_weather_probability_decisions = True
+End Function
+
+Private Function test_weather_state_transitions() As Boolean
+    Call ResetMeteo(False)
+    Call SetAtmosphericFogState(True, 31)
+    If Not ServidorNublado Or Not Nieblando Or IntensidadDeNubes <> 31 Then Exit Function
+    Call SetPrecipitationState(True)
+    If Not Lloviendo Or Not Nebando Then Exit Function
+    Call SetAtmosphericFogState(False)
+    If ServidorNublado Or Nieblando Or IntensidadDeNubes <> 0 Then Exit Function
+    If Not Lloviendo Or Not Nebando Then Exit Function
+    Call SetPrecipitationState(False)
+    test_weather_state_transitions = Not Lloviendo And Not Nebando
 End Function
 
 Private Function test_weather_reset_decisions() As Boolean
@@ -57,7 +89,9 @@ Private Function test_weather_canonical_reset() As Boolean
     test_weather_canonical_reset = Not Lloviendo And Not Nebando And _
         Not ServidorNublado And Not Nieblando And _
         Not frmMain.Truenos.Enabled And frmMain.TimerMeteorologia.Enabled And _
-        TimerMeteorologico = 30
+        TimerMeteorologico = METEOROLOGICAL_CYCLE_MINUTES And _
+        ProbabilidadNublar = 0 And ProbabilidadLLuvia = 0 And _
+        IntensidadDeNubes = 0
 End Function
 
 #End If

--- a/Codigo/frmMain.frm
+++ b/Codigo/frmMain.frm
@@ -1411,65 +1411,49 @@ End Sub
 
 
 Private Sub TimerMeteorologia_Timer()
-    'Call SendData(SendTarget.ToAll, 0, PrepareMessageLocaleMsg(MSG_SERVIDOR_TIMER_LLUVIA, TimerMeteorologico, e_FontTypeNames.FONTTYPE_SERVER)) 'Msg1741=Servidor > Timer de lluvia en : ¬1
     On Error GoTo TimerMeteorologia_Timer_Err
-    If TimerMeteorologico > 7 Then
-        TimerMeteorologico = TimerMeteorologico - 1
-        Exit Sub
+
+    If TimerMeteorologico = 0 Or TimerMeteorologico > METEOROLOGICAL_CYCLE_MINUTES Then
+        TimerMeteorologico = METEOROLOGICAL_CYCLE_MINUTES
     End If
-    If TimerMeteorologico = 7 Then
-        ProbabilidadNublar = RandomNumber(1, 3)
-        If ProbabilidadNublar = 1 Then
+
+    If TimerMeteorologico = METEOROLOGICAL_CLOUD_COUNTDOWN_MINUTES Then
+        ProbabilidadNublar = RandomNumber(1, 2)
+        If WeatherCloudRollSucceeds(ProbabilidadNublar) Then
             IntensidadDeNubes = RandomNumber(10, 45)
-            Nieblando = True
-            ServidorNublado = True
-            'Enviar Nubes a todos
+            Call SetAtmosphericFogState(True, IntensidadDeNubes)
             Call SendData(SendTarget.ToAll, 0, PrepareMessageNieblandoToggle(IntensidadDeNubes))
-            ' Call SendData(SendTarget.ToAll, 0, PrepareMessageConsoleMsg("Servidor > Empezaron las nubes con intensidad: " & IntensidadDeNubes & "%.", e_FontTypeNames.FONTTYPE_SERVER))
-            Call AgregarAConsola("Servidor » Empezaron las nubes")
-            TimerMeteorologico = TimerMeteorologico - 1
+            Call AgregarAConsola("Servidor - Empezaron las nubes")
         Else
-            ' Call SendData(SendTarget.ToAll, 0, PrepareMessageConsoleMsg("Servidor > Tranquilo, no hay nubes ni va a llover.", e_FontTypeNames.FONTTYPE_SERVER))
-            Call AgregarAConsola("Servidor » Tranquilo, no hay nubes ni va a llover.")
-            Call ResetMeteo(True)
-            Exit Sub
+            Call AgregarAConsola("Servidor - Tiempo despejado.")
+        End If
+    ElseIf TimerMeteorologico < METEOROLOGICAL_CLOUD_COUNTDOWN_MINUTES And _
+            TimerMeteorologico > METEOROLOGICAL_PRECIPITATION_COUNTDOWN_MINUTES Then
+        If IsAtmosphericFogActive() Then
+            Truenos.Enabled = True
+        End If
+    ElseIf TimerMeteorologico = METEOROLOGICAL_PRECIPITATION_COUNTDOWN_MINUTES Then
+        If IsAtmosphericFogActive() Then
+            ProbabilidadLLuvia = RandomNumber(1, 5)
+            If WeatherPrecipitationRollSucceeds(ProbabilidadLLuvia, True) Then
+                Call SetPrecipitationState(True)
+                Call SendData(SendTarget.ToAll, 0, PrepareMessagePlayWave(404, NO_3D_SOUND, NO_3D_SOUND))
+                Call SendData(SendTarget.ToAll, 0, PrepareMessageFlashScreen(&HD254D6, 250))
+                Call SendData(SendTarget.ToAll, 0, PrepareMessageRainToggle())
+                Call SendData(SendTarget.ToAll, 0, PrepareMessageNevarToggle())
+                Call AgregarAConsola("Servidor - Empezo la precipitacion.")
+            Else
+                Truenos.Enabled = False
+                Call AgregarAConsola("Servidor - Las nubes continuan sin precipitacion.")
+            End If
         End If
     End If
-    If TimerMeteorologico < 7 And TimerMeteorologico > 3 Then
-        TimerMeteorologico = TimerMeteorologico - 1
-        'Enviar Truenos y rayos
-        Truenos.Enabled = True
-        'Call SendData(SendTarget.ToAll, 0, PrepareMessageConsoleMsg("Servidor > Envio un truenito para que te asustes.", e_FontTypeNames.FONTTYPE_SERVER))
-        Call AgregarAConsola("Servidor » Truenos y nubes activados.")
-        Exit Sub
-    End If
-    If TimerMeteorologico = 3 Then
-        ProbabilidadLLuvia = RandomNumber(1, 5)
-        If ProbabilidadLLuvia = 1 Then
-            'Envia Lluvia
-            Nebando = True
-            Lloviendo = True
-            Call SendData(SendTarget.ToAll, 0, PrepareMessagePlayWave(404, NO_3D_SOUND, NO_3D_SOUND)) ' Explota un trueno
-            Call SendData(SendTarget.ToAll, 0, PrepareMessageFlashScreen(&HD254D6, 250)) 'Rayo
-            Call SendData(SendTarget.ToAll, 0, PrepareMessageRainToggle())
-            Call SendData(SendTarget.ToAll, 0, PrepareMessageNevarToggle())
-            Call AgregarAConsola("Servidor » Lloviendo.")
-            TimerMeteorologico = TimerMeteorologico - 1
-        Else
-            Call AgregarAConsola("Servidor » Truenos y nubes desactivados.")
-            Call ResetMeteo(True)
-            Exit Sub
-        End If
-    End If
-    If TimerMeteorologico < 3 And TimerMeteorologico > 0 Then
-        TimerMeteorologico = TimerMeteorologico - 1
-        Exit Sub
-    End If
-    If TimerMeteorologico = 0 Then
-        'dejar de llover y sacar nubes
-        Call AgregarAConsola("Servidor >Lluvia desactivada.")
+
+    If TimerMeteorologico = 1 Then
+        Call AgregarAConsola("Servidor - Ciclo meteorologico finalizado.")
         Call ResetMeteo(True)
-        Exit Sub
+    Else
+        TimerMeteorologico = TimerMeteorologico - 1
     End If
     Exit Sub
 TimerMeteorologia_Timer_Err:


### PR DESCRIPTION
## Summary

Makes the existing VB6 meteorological system visible often enough for normal play while preserving its existing protocol and map-driven rain, snow, and fog presentation.

The previous scheduler nominally used a 30-minute cycle, but failed cloud and precipitation rolls reset it early. Clouds had a 1/3 chance, precipitation had a further 1/5 conditional chance, and successful precipitation lasted only about 2 minutes. This produced precipitation approximately once every 382 minutes on average and active for roughly 0.5% of playtime.

## What changed

- Replaced the early-resetting schedule with a fixed 20-minute cycle.
- Rolls for clouds at minute 10 with a 50% chance.
- Rolls for precipitation at minute 15 with a 40% chance, only while cloudy.
- Keeps successful fog active for 10 minutes.
- Keeps successful precipitation active for 5 minutes.
- Continues setting both **Lloviendo** and **Nebando**; client map CSM flags still select rain versus snow.
- Keeps failed rolls in the current cycle instead of immediately restarting it.
- Makes **/NIEBLA** toggle fog/cloud state rather than resetting all weather.
- Keeps **ServidorNublado** and **Nieblando** synchronized.
- Clears probability, intensity, and legacy duration fields during **ResetMeteo**.
- Preserves the previous fog intensity while serializing the existing toggle-based OFF notification.

The new long-run expectation is:

- 20% precipitation chance per cycle.
- One precipitation event approximately every 100 minutes.
- Fog active approximately 25% of playtime.
- Precipitation active approximately 5% of playtime.
- Clear weather remains the majority state.

## Existing fixes preserved

- Snow state is synchronized when a player logs in.
- ResetMeteo clears rain, snow, fog, and thunder state.
- Live resets send transition-aware rain, snow, and fog OFF notifications.
- An already-clear reset does not accidentally toggle fog on.

## Compatibility

- No packet IDs or packet payload formats changed.
- No ProtocolGenerator changes.
- No HOO or legacy VB6 client changes.
- No CSM format or map changes.
- Existing LLUVIA, NIEVE, and niebla map flags continue selecting the visible effect client-side.

## Tests

Expanded **Unit_Weather** coverage for scheduler milestones, probability decisions, canonical reset state, fog toggling, login synchronization, and packet-selection behavior.

## Validation performed

- Windows VB6 unit-test build: passed.
- Complete unit suite: **328 / 328 passed**.
- Production-style server build with **PYMMO=1** and **UNIT_TEST=0**: passed.
- **git diff --check**: passed; only the repository line-ending warning was emitted.
- No live visual server/client weather test was performed.

## Risks / TODOs

The legacy fog packet remains toggle-based rather than carrying an explicit boolean. This change preserves that wire format and carefully sends fog packets only on actual state transitions.