### PR TITLE
fix(inventory): repair orphaned equipped shields

### DIFF
--- a/Codigo/CharacterPersistence.bas
+++ b/Codigo/CharacterPersistence.bas
@@ -155,6 +155,7 @@ Public Function LoadCharacterInventory(ByVal UserIndex As Integer) As Boolean
         Dim RS                As ADODB.Recordset
         Dim counter           As Long
         Dim SQLQuery          As String
+        Dim QueryBreakdown   As String
         Dim max_slots_to_load As Integer
         'Load all slots to avoid destroying items when user stops being patreon
         max_slots_to_load = get_num_inv_slots_from_tier(tLeyenda)
@@ -188,6 +189,9 @@ Public Function LoadCharacterInventory(ByVal UserIndex As Integer) As Boolean
                 RS.MoveNext
             Wend
             .invent.NroItems = counter
+        End If
+        If NormalizarEscudoEquipado(UserIndex, True) Then
+            Call SaveCharacterInventoryDB(UserList(UserIndex), QueryBreakdown)
         End If
     End With
     LoadCharacterInventory = True

--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -363,6 +363,80 @@ QuitarUserInvItem_Err:
     Call TraceError(Err.Number, Err.Description, "InvUsuario.QuitarUserInvItem", Erl)
 End Sub
 
+Public Function NormalizarEscudoEquipado(ByVal UserIndex As Integer, Optional ByVal UserIsLoggingIn As Boolean = False) As Boolean
+    On Error GoTo NormalizarEscudoEquipado_Err
+
+    Dim RegisteredShieldSlot As Byte
+    Dim Slot As Integer
+    Dim LastSlot As Integer
+    Dim ObjIndex As Integer
+    Dim InventoryChanged As Boolean
+
+    With UserList(UserIndex)
+        RegisteredShieldSlot = .invent.EquippedShieldSlot
+        LastSlot = .CurrentInventorySlots
+        If LastSlot > UBound(.invent.Object) Then LastSlot = UBound(.invent.Object)
+
+        If RegisteredShieldSlot < LBound(.invent.Object) Or RegisteredShieldSlot > LastSlot Then
+            RegisteredShieldSlot = 0
+        Else
+            ObjIndex = .invent.Object(RegisteredShieldSlot).ObjIndex
+            If ObjIndex <= 0 Or ObjIndex > UBound(ObjData) Then
+                RegisteredShieldSlot = 0
+            ElseIf ObjData(ObjIndex).OBJType <> e_OBJType.otShield Then
+                RegisteredShieldSlot = 0
+            End If
+        End If
+
+        If RegisteredShieldSlot = 0 Then
+            .invent.EquippedShieldObjIndex = 0
+            .invent.EquippedShieldSlot = 0
+            .Char.ShieldAnim = NingunEscudo
+            .Char.Escudo_Aura = 0
+        Else
+            .invent.EquippedShieldSlot = RegisteredShieldSlot
+            .invent.EquippedShieldObjIndex = .invent.Object(RegisteredShieldSlot).ObjIndex
+            If .invent.Object(RegisteredShieldSlot).Equipped = 0 Then
+                .invent.Object(RegisteredShieldSlot).Equipped = 1
+                InventoryChanged = True
+                Call UpdateUserInv(False, UserIndex, RegisteredShieldSlot)
+            End If
+        End If
+
+        If LastSlot >= LBound(.invent.Object) Then
+            For Slot = LBound(.invent.Object) To LastSlot
+                ObjIndex = .invent.Object(Slot).ObjIndex
+                If ObjIndex > 0 And ObjIndex <= UBound(ObjData) Then
+                    If ObjData(ObjIndex).OBJType = e_OBJType.otShield Then
+                        If .invent.Object(Slot).Equipped <> 0 And Slot <> RegisteredShieldSlot Then
+                            .invent.Object(Slot).Equipped = 0
+                            InventoryChanged = True
+                            Call UpdateUserInv(False, UserIndex, CByte(Slot))
+                            Call LogError("Desequipar: flag Equipped huerfano limpiado. Usuario=" & .name & _
+                                          " Slot=" & Slot & " ObjIndex=" & ObjIndex & _
+                                          " SlotRegistrado=" & RegisteredShieldSlot)
+                        End If
+                    End If
+                End If
+            Next Slot
+        End If
+
+        If InventoryChanged Then
+            .flags.ModificoInventario = True
+        End If
+
+        If RegisteredShieldSlot = 0 And Not UserIsLoggingIn Then
+            Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessageAuraToChar(.Char.charindex, 0, True, 3))
+            Call ChangeUserChar(UserIndex, .Char.body, .Char.head, .Char.Heading, .Char.WeaponAnim, .Char.ShieldAnim, .Char.CascoAnim, .Char.CartAnim, .Char.BackpackAnim)
+        End If
+    End With
+
+    NormalizarEscudoEquipado = InventoryChanged
+    Exit Function
+NormalizarEscudoEquipado_Err:
+    Call TraceError(Err.Number, Err.Description, "InvUsuario.NormalizarEscudoEquipado", Erl)
+End Function
+
 Public Sub UpdateUserInv(ByVal UpdateAll As Boolean, ByVal UserIndex As Integer, ByVal Slot As Byte)
     On Error GoTo UpdateUserInv_Err
     Dim NullObj As t_UserOBJ

--- a/Codigo/modBanco.bas
+++ b/Codigo/modBanco.bas
@@ -200,6 +200,16 @@ Sub UserDepositaItem(ByVal UserIndex As Integer, ByVal Slot As Integer, ByVal Ca
     End If
     If UserList(UserIndex).invent.Object(Slot).amount > 0 And Cantidad > 0 Then
         If Cantidad > UserList(UserIndex).invent.Object(Slot).amount Then Cantidad = UserList(UserIndex).invent.Object(Slot).amount
+        If UserList(UserIndex).invent.Object(Slot).ObjIndex > 0 And _
+           UserList(UserIndex).invent.Object(Slot).ObjIndex <= UBound(ObjData) Then
+            If ObjData(UserList(UserIndex).invent.Object(Slot).ObjIndex).OBJType = e_OBJType.otShield Then
+                Call NormalizarEscudoEquipado(UserIndex)
+                If UserList(UserIndex).invent.Object(Slot).Equipped <> 0 Then
+                    Call WriteConsoleMsg(UserIndex, "No podes depositar un objeto equipado.", e_FontTypeNames.FONTTYPE_INFO)
+                    Exit Sub
+                End If
+            End If
+        End If
         'Agregamos el obj que deposita al banco
         slotdestino = UserDejaObj(UserIndex, CInt(Slot), Cantidad, slotdestino)
         'Actualizamos el inventario del usuario

--- a/Codigo/modNetwork.bas
+++ b/Codigo/modNetwork.bas
@@ -240,6 +240,14 @@ Private Sub OnServerRecv(ByVal Connection As Long, ByVal Message As Network.read
         '       HandleLoginNewChar(ConnectionID)
         ' It does not make sense to pass the index if it has not being assigned
         Call Protocol.HandleIncomingData(Connection, Message, UserRef.ArrayIndex)
+    ElseIf UserRef.ArrayIndex > 0 Then
+        If UserRef.ArrayIndex <= UBound(UserList) Then
+            Call LogUserRefError(UserRef, "modNetwork.OnServerRecv")
+        Else
+            Call LogError("Failed to validate UserRef index(" & UserRef.ArrayIndex & ") At: modNetwork.OnServerRecv")
+        End If
+        Call KickConnection(Connection)
+        Exit Sub
     Else
         Call Protocol.HandleIncomingData(Connection, Message)
     End If


### PR DESCRIPTION
## Summary
- Normaliza el estado de escudos con flags `Equipped` huérfanos y evita que el estado inválido reaparezca al reloguear.
- Permite depositar un escudo cuando el flag huérfano se puede reparar y bloquea únicamente el escudo realmente equipado.
- Descarta conexiones con `UserRef` obsoleta o inválida para evitar procesar paquetes con una referencia de usuario inconsistente.

## Testing
- PASS: compilación VB6 con `Server.VBP` (`La generación de 'server.exe' ha tenido éxito.`).
- PASS: `git diff --check`.
- PASS: validación estática de las cuatro rutas modificadas, encoding CP1252, CRLF y aserciones del parche.
- WARN: el verificador genérico de protocolo AOMania no aplica a este fork; no se modificaron opcodes ni campos de paquetes.
- NOT_RUN: reproducción funcional con las cuentas `KikiNasti`/`DonGato` y ejecución del servidor contra una base de datos real.

## Changelog
- No se añadió fragmento: este repositorio no contiene `tools/changelog.py`, plantilla de PR ni `changelog/unreleased`.