### PR TITLE
Remove extra read in leave-party handler

### DIFF
--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -7238,7 +7238,6 @@ Private Sub HandleAbandonarGrupo(ByVal UserIndex As Integer)
     'Author: Pablo Mercavides
     On Error GoTo HandleAbandonarGrupo_Err
     With UserList(UserIndex)
-        Call reader.ReadInt16
         If UserList(UserIndex).Grupo.Lider.ArrayIndex = UserIndex Then
             Call FinalizarGrupo(UserIndex)
         Else


### PR DESCRIPTION
Drop an unused `reader.ReadInt16` call in `HandleAbandonarGrupo`. The packet handler now only performs the group-leave logic, avoiding consumption of unexpected payload bytes and keeping packet parsing aligned.