### PR TITLE
Block potion use in castle zones

### DIFF
--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -2804,6 +2804,7 @@ Public Function IsConsumableFreeZone(ByVal UserIndex As Integer) As Boolean
     Dim isTriggerZone  As Boolean
     Dim isTierUser     As Boolean
     Dim isHouseZone    As Boolean
+    Dim isCastleZone   As Boolean
     Dim isSpecialZone  As Boolean
     Dim isTrainingZone As Boolean
     Dim isArena        As Boolean
@@ -2818,6 +2819,8 @@ Public Function IsConsumableFreeZone(ByVal UserIndex As Integer) As Boolean
     isTierUser = IsPatreon(UserIndex)
     ' Zona de casas/sotanos arenas: mapas del 600 al 749 con trigger activo
     isHouseZone = (currentMap >= 600 And currentMap <= 749 And isTriggerZone)
+    ' Zona de castillos: mapas del 758 al 772
+    isCastleZone = (currentMap >= 758 And currentMap <= 772)
     ' Zonas especiales fijas donde no se consumen pociones
     ' 275, 276, 277 - Capture the Flag
     Select Case currentMap
@@ -2831,7 +2834,7 @@ Public Function IsConsumableFreeZone(ByVal UserIndex As Integer) As Boolean
     ' Meson Hostigado - Beneficio Patreon: mapa 172, con trigger activo y jugador con tier
     isTrainingZone = (currentMap = MAP_MESON_HOSTIGADO And isTriggerZone And isTierUser)
     ' Si esta en alguna de las zonas anteriores, no se consume la poción
-    IsConsumableFreeZone = (isHouseZone Or isSpecialZone Or isTrainingZone Or isArena)
+    IsConsumableFreeZone = (isHouseZone Or isCastleZone Or isSpecialZone Or isTrainingZone Or isArena)
 End Function
 
 Sub EnivarArmasConstruibles(ByVal UserIndex As Integer)


### PR DESCRIPTION
Adds castle maps (758-772) to the list of areas where consumables are disabled. This prevents potion use in castle zones alongside house, arena, training, and special restricted areas.